### PR TITLE
Peeking Circuit Breaker

### DIFF
--- a/service/matrix-adapter.yml
+++ b/service/matrix-adapter.yml
@@ -101,7 +101,20 @@ matrix:
       # Room ranges to sync [start, end] indices
       ranges: ${MATRIX_SLIDING_SYNC_RANGES}:[[0,99]]
 
+      # Circuit breaker configuration for peek operations
+      circuitBreaker:
+        # Maximum number of failures before opening the circuit
+        failureThreshold: ${MATRIX_CIRCUIT_BREAKER_FAILURE_THRESHOLD}:5
+        # Initial timeout in milliseconds when circuit is open
+        initialTimeout: ${MATRIX_CIRCUIT_BREAKER_INITIAL_TIMEOUT}:1000
+        # Maximum timeout in milliseconds for exponential backoff
+        maxTimeout: ${MATRIX_CIRCUIT_BREAKER_MAX_TIMEOUT}:30000
+        # Maximum number of retry attempts for peek operations
+        maxRetries: ${MATRIX_CIRCUIT_BREAKER_MAX_RETRIES}:5
+
   admin:
     # The admin account that is created / used to administer the regular users on the Synapse server
     username: ${SYNAPSE_ADMIN_USERNAME}:matrixadmin3@alkem.io
     password: ${SYNAPSE_ADMIN_PASSWORD}:change_me_now
+
+

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-matrix-adapter",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Alkemio Matrix Adapter service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/service/src/domain/agent/agent/matrix.agent.ts
+++ b/service/src/domain/agent/agent/matrix.agent.ts
@@ -62,7 +62,6 @@ export class MatrixAgent implements Disposable {
     this.eventDispatcher = new MatrixEventDispatcher(this);
     this.configService = configService;
     this.messageAdapter = messageAdapter;
-    this.logger = logger;
 
     // Read circuit breaker configuration from ConfigService
     const circuitBreakerConfig: CircuitBreakerConfig = {

--- a/service/src/domain/agent/agent/matrix.agent.ts
+++ b/service/src/domain/agent/agent/matrix.agent.ts
@@ -1,6 +1,6 @@
 import { IMessage } from '@alkemio/matrix-adapter-lib';
 import { LogContext } from '@common/enums/logging.context';
-import pkg from '@nestjs/common';
+import pkg, { Inject } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ConfigurationTypes } from '@src/common/enums/configuration.type';
 import { MatrixEntityNotFoundException } from '@src/common/exceptions/matrix.entity.not.found.exception';
@@ -28,61 +28,16 @@ import { SlidingSync } from 'matrix-js-sdk/lib/sliding-sync.js';
 import { SlidingSyncSdk } from 'matrix-js-sdk/lib/sliding-sync-sdk.js';
 import { SyncApi } from 'matrix-js-sdk/lib/sync.js';
 import { RoomMessageEventContent } from 'matrix-js-sdk/lib/types';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 import { IConditionalMatrixEventHandler } from '../events/matrix.event.conditional.handler.interface';
 import { IMatrixEventHandler } from '../events/matrix.event.handler.interface';
 import { MatrixEventsInternalNames } from '../events/types/matrix.event.internal.names';
 import { SlidingSyncConfig } from './matrix.sliding.sync.config';
+import { CircuitBreakerConfig,PeekCircuitBreaker } from './peek.circuit.breaker';
 import { MatrixAgentStartOptions } from './type/matrix.agent.start.options';
 
-type CircuitBreakerState = "CLOSED" | "OPEN" | "HALF_OPEN";
 
-class PeekCircuitBreaker {
-  private state: CircuitBreakerState = "CLOSED";
-  private failureCount = 0;
-  private lastFailureTime = 0;
-  private readonly failureThreshold = 5;
-  private resetTimeout = 250; // Start with 250 milliseconds
-  private readonly maxResetTimeout = 30000; // Max 30 seconds
-
-  public async attemptPeek<T>(fn: () => Promise<T>, roomId: string): Promise<T> {
-    if (this.state === "OPEN") {
-      const timeSinceFailure = Date.now() - this.lastFailureTime;
-      if (timeSinceFailure < this.resetTimeout) {
-        throw new Error(
-          `Circuit breaker is open for room ${roomId}. Retry after ${this.resetTimeout - timeSinceFailure}ms`
-        );
-      } else {
-        // Transition to HALF_OPEN and allow a single test request
-        this.state = "HALF_OPEN";
-      }
-    }
-
-    try {
-      const result = await fn();
-      // Reset on success
-      this.state = "CLOSED";
-      this.failureCount = 0;
-      this.resetTimeout = 250; // Reset to initial timeout
-      return result;
-    } catch (error) {
-      this.failureCount++;
-      this.lastFailureTime = Date.now();
-
-      // Apply exponential backoff
-      this.resetTimeout = Math.min(
-        this.maxResetTimeout,
-        this.resetTimeout * 2
-      );
-
-      if (this.failureCount >= this.failureThreshold) {
-        this.state = "OPEN";
-      }
-
-      throw error;
-    }
-  }
-}
 
 // Wraps an instance of the client sdk
 export class MatrixAgent implements Disposable {
@@ -94,18 +49,37 @@ export class MatrixAgent implements Disposable {
   slidingSyncSdk?: SlidingSyncSdk;
   syncApi?: SyncApi;
   // Initialize the circuit breaker
-  private peekCircuitBreaker = new PeekCircuitBreaker();
+  private peekCircuitBreaker: PeekCircuitBreaker;
 
   constructor(
     matrixClient: MatrixClient,
     configService: ConfigService,
     messageAdapter: MatrixMessageAdapter,
-    private logger: pkg.LoggerService
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: pkg.LoggerService,
   ) {
     this.matrixClient = matrixClient;
     this.eventDispatcher = new MatrixEventDispatcher(this);
     this.configService = configService;
     this.messageAdapter = messageAdapter;
+    this.logger = logger;
+
+    // Read circuit breaker configuration from ConfigService
+    const circuitBreakerConfig: CircuitBreakerConfig = {
+      failureThreshold: configService.get<number>('matrix.client.slidingSync.circuitBreaker.failureThreshold', 5),
+      initialTimeout: configService.get<number>('matrix.client.slidingSync.circuitBreaker.initialTimeout', 1000),
+      maxTimeout: configService.get<number>('matrix.client.slidingSync.circuitBreaker.maxTimeout', 30000),
+      maxRetries: configService.get<number>('matrix.client.slidingSync.circuitBreaker.maxRetries', 5)
+    };
+
+    // Debug log the configuration
+    this.logger.verbose?.(
+      `Circuit breaker config loaded: ${JSON.stringify(circuitBreakerConfig)}`,
+      LogContext.COMMUNICATION
+    );
+
+    // Initialize circuit breaker with logger and configuration
+    this.peekCircuitBreaker = new PeekCircuitBreaker(this.logger, circuitBreakerConfig);
   }
 
   attach(handler: IMatrixEventHandler) {
@@ -249,30 +223,34 @@ export class MatrixAgent implements Disposable {
     );
   }
 
-  public async getRoomOrFail(roomId: string, maxRetries = 5): Promise<MatrixRoom> {
-    // First, check if the room is already in the cache
-    let matrixRoom = this.matrixClient.getRoom(roomId);
-    if (matrixRoom) {
-      return matrixRoom;
-    }
+  public async getRoomOrFail(roomId: string, maxRetries?: number): Promise<MatrixRoom> {
+    // Use configured max retries if not provided
+    const retryLimit = maxRetries ?? this.peekCircuitBreaker.getMaxRetries();
 
-    // If not, attempt to peek with retry logic
+    // First check cache
+    let matrixRoom = this.matrixClient.getRoom(roomId);
+    if (matrixRoom) return matrixRoom;
+
     if (this.syncApi) {
       let lastError: unknown;
 
-      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      for (let attempt = 1; attempt <= retryLimit; attempt++) {
         try {
           matrixRoom = await this.peekCircuitBreaker.attemptPeek(
             () => this.syncApi!.peek(roomId),
-            roomId
+            roomId,
+            attempt,
+            retryLimit
           );
-          break; // Success - exit retry loop
+          break;
         } catch (error) {
           lastError = error;
-          if (attempt < maxRetries) {
-            // Wait with exponential backoff
-            const delay = Math.min(1000 * Math.pow(2, attempt), 5000); // Max 5s delay
-            this.logger.debug?.(`Peek attempt ${attempt} failed for room ${roomId}. Retrying in ${delay}ms...`);
+          if (attempt < retryLimit) {
+            const delay = Math.min(500 * Math.pow(2, attempt), 5000);
+            this.logger.verbose?.(
+              `Peek attempt ${attempt}/${retryLimit} failed for room ${roomId}. ` +
+              `Retrying in ${delay}ms...`
+            );
             await new Promise(resolve => setTimeout(resolve, delay));
           }
         }
@@ -280,13 +258,14 @@ export class MatrixAgent implements Disposable {
 
       if (!matrixRoom) {
         throw new MatrixEntityNotFoundException(
-          `Failed to peek room ${roomId} after ${maxRetries} attempts. Last error: ${lastError}`,
+          `Failed to peek room ${roomId} after ${retryLimit} attempts. ` +
+          `Last error: ${lastError}`,
           LogContext.MATRIX
         );
       }
     }
 
-    // Verify the room was loaded after peeking
+    // Verify room was loaded
     matrixRoom = this.matrixClient.getRoom(roomId);
     if (!matrixRoom) {
       throw new MatrixEntityNotFoundException(
@@ -297,6 +276,7 @@ export class MatrixAgent implements Disposable {
 
     return matrixRoom;
   }
+
 
 
   resolveAutoAcceptRoomMembershipMonitor(
@@ -443,6 +423,20 @@ export class MatrixAgent implements Disposable {
 
     dmRooms[userId] = [roomId];
     await agent.matrixClient.setAccountData(EventType.Direct, dmRooms);
+  }
+
+  /**
+   * Get circuit breaker status for monitoring/debugging
+   */
+  public getCircuitBreakerStatus() {
+    return this.peekCircuitBreaker.getStatus();
+  }
+
+  /**
+   * Log circuit breaker status for debugging
+   */
+  public logCircuitBreakerStatus(roomId?: string) {
+    this.peekCircuitBreaker.logStatus(roomId);
   }
 
   dispose() {

--- a/service/src/domain/agent/agent/peek.circuit.breaker.ts
+++ b/service/src/domain/agent/agent/peek.circuit.breaker.ts
@@ -83,7 +83,7 @@ export class PeekCircuitBreaker {
         );
         this.state = "CLOSED";
         this.failureCount = 0;
-        this.resetTimeout = 1000;
+        this.resetTimeout = this.config.initialTimeout; // Reset timeout on success
       } else {
         this.logger.verbose?.(
           `Circuit breaker request successful for room ${roomId} (took ${duration}ms)`,

--- a/service/src/domain/agent/agent/peek.circuit.breaker.ts
+++ b/service/src/domain/agent/agent/peek.circuit.breaker.ts
@@ -1,0 +1,177 @@
+import { LoggerService } from '@nestjs/common';
+import { LogContext } from '@src/common/enums/logging.context';
+
+type CircuitBreakerState = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+export interface CircuitBreakerConfig {
+  failureThreshold: number;
+  initialTimeout: number;
+  maxTimeout: number;
+  maxRetries: number;
+}
+
+export class PeekCircuitBreaker {
+  private state: CircuitBreakerState = "CLOSED";
+  private failureCount = 0;
+  private lastFailureTime = 0;
+  private readonly failureThreshold: number;
+  private resetTimeout: number;
+  private readonly maxResetTimeout: number;
+  private readonly maxRetries: number;
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly config: CircuitBreakerConfig
+  ) {
+    this.failureThreshold = config.failureThreshold;
+    this.resetTimeout = config.initialTimeout;
+    this.maxResetTimeout = config.maxTimeout;
+    this.maxRetries = config.maxRetries;
+
+    this.logger.verbose?.(
+      `Circuit breaker initialized with failure threshold: ${this.failureThreshold}, initial timeout: ${this.resetTimeout}ms, max timeout: ${this.maxResetTimeout}ms, max retries: ${this.maxRetries}`,
+      LogContext.COMMUNICATION
+    );
+  }
+
+  public async attemptPeek<T>(
+    fn: () => Promise<T>,
+    roomId: string,
+    attempt: number,
+    maxAttempts: number
+  ): Promise<T> {
+    const startTime = Date.now();
+
+    this.logger.verbose?.(
+      `Circuit breaker attempt ${attempt}/${maxAttempts} for room ${roomId} - State: ${this.state}, Failure count: ${this.failureCount}`,
+      LogContext.COMMUNICATION
+    );
+
+    // Only check circuit state if we're not on the first attempt
+    if (attempt > 1) {
+      if (this.state === "OPEN") {
+        const timeSinceFailure = Date.now() - this.lastFailureTime;
+        if (timeSinceFailure < this.resetTimeout) {
+          const remainingTime = this.resetTimeout - timeSinceFailure;
+          this.logger.warn?.(
+            `Circuit breaker is OPEN for room ${roomId}. Blocking request. Retry after ${remainingTime}ms (${Math.round(remainingTime / 1000)}s)`,
+            LogContext.COMMUNICATION
+          );
+          throw new Error(
+            `Circuit breaker is open for room ${roomId}. ` +
+            `Retry after ${remainingTime}ms`
+          );
+        } else {
+          this.logger.verbose?.(
+            `Circuit breaker transitioning from OPEN to HALF_OPEN for room ${roomId} - Allowing test request`,
+            LogContext.COMMUNICATION
+          );
+          this.state = "HALF_OPEN";
+        }
+      }
+    }
+
+    try {
+      const result = await fn();
+      const duration = Date.now() - startTime;
+
+      // Reset on success
+      if (this.state !== "CLOSED") {
+        this.logger.verbose?.(
+          `Circuit breaker SUCCESS - Transitioning to CLOSED for room ${roomId} (took ${duration}ms)`,
+          LogContext.COMMUNICATION
+        );
+        this.state = "CLOSED";
+        this.failureCount = 0;
+        this.resetTimeout = 1000;
+      } else {
+        this.logger.verbose?.(
+          `Circuit breaker request successful for room ${roomId} (took ${duration}ms)`,
+          LogContext.COMMUNICATION
+        );
+      }
+
+      return result;
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      this.failureCount++;
+      this.lastFailureTime = Date.now();
+
+      this.logger.warn?.(
+        `Circuit breaker FAILURE ${this.failureCount}/${this.failureThreshold} for room ${roomId} (took ${duration}ms) - Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        LogContext.COMMUNICATION
+      );
+
+      // Only apply backoff if we're not on the last attempt
+      if (attempt < maxAttempts) {
+        const oldTimeout = this.resetTimeout;
+        this.resetTimeout = Math.min(
+          this.maxResetTimeout,
+          this.resetTimeout * 2
+        );
+
+        if (oldTimeout !== this.resetTimeout) {
+          this.logger.verbose?.(
+            `Circuit breaker applying exponential backoff for room ${roomId}: ${oldTimeout}ms → ${this.resetTimeout}ms`,
+            LogContext.COMMUNICATION
+          );
+        }
+      }
+
+      // Only open circuit if we've exhausted all attempts
+      if (attempt >= maxAttempts && this.failureCount >= this.failureThreshold) {
+        const previousState = this.state;
+        this.state = "OPEN";
+        this.logger.error?.(
+          `Circuit breaker OPENING for room ${roomId} - Failure threshold reached (${this.failureCount}/${this.failureThreshold}). ` +
+          `Previous state: ${previousState}. Next retry allowed in ${this.resetTimeout}ms (${Math.round(this.resetTimeout / 1000)}s)`,
+          LogContext.COMMUNICATION
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Get the maximum number of retries configured
+   */
+  public getMaxRetries(): number {
+    return this.maxRetries;
+  }
+
+  /**
+   * Get current circuit breaker status for monitoring/debugging
+   */
+  public getStatus() {
+    const timeSinceLastFailure = this.lastFailureTime ? Date.now() - this.lastFailureTime : null;
+    const nextRetryAllowedIn = this.state === "OPEN" && timeSinceLastFailure !== null
+      ? Math.max(0, this.resetTimeout - timeSinceLastFailure)
+      : 0;
+
+    return {
+      state: this.state,
+      failureCount: this.failureCount,
+      failureThreshold: this.failureThreshold,
+      resetTimeout: this.resetTimeout,
+      maxResetTimeout: this.maxResetTimeout,
+      lastFailureTime: this.lastFailureTime,
+      timeSinceLastFailure,
+      nextRetryAllowedIn,
+      isHealthy: this.state === "CLOSED" && this.failureCount === 0
+    };
+  }
+
+  /**
+   * Log current circuit breaker status
+   */
+  public logStatus(roomId?: string) {
+    const status = this.getStatus();
+    const roomInfo = roomId ? ` for room ${roomId}` : '';
+
+    this.logger.verbose?.(
+      `Circuit breaker status${roomInfo}: ${JSON.stringify(status, null, 2)}`,
+      LogContext.COMMUNICATION
+    );
+  }
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Resolves #84

## Summary by CodeRabbit

* **New Features**
  * Introduced a circuit breaker mechanism to improve reliability when peeking rooms, with configurable thresholds, timeouts, and retry limits.
  * Added enhanced logging and monitoring capabilities for circuit breaker status and operations.
  * Users may experience more robust handling of temporary failures during room peeking, reducing disruptions.

* **Configuration**
  * New environment variables allow customization of circuit breaker parameters for peek operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

During implementation, different approaches were considered & tried:
- trying to sync the state of peeking
- waiting for all peeks to be finalized
- circuit breaker

Logs from `synapse` didn't show any errors, so the only sustainable and robust, working solution, that could work also with network-level errors, was circuit breaker. There is a custom build deployed & tested on dev and acc by @valentinyanakiev  and @Comoque1, working well. Logs show that quite often the circuit breaker logic is hit.