### PR TITLE
Improves peek circuit breaker resilience

### DIFF
--- a/service/src/domain/agent/agent/peek.circuit.breaker.ts
+++ b/service/src/domain/agent/agent/peek.circuit.breaker.ts
@@ -136,6 +136,7 @@ export class PeekCircuitBreaker {
         this.logger.error?.(
           `Circuit breaker OPENING for room ${roomId} due to non-retryable error (403 not in room / previews disabled). ` +
           `Previous state: ${previousState}. Timeout ${oldTimeout}ms → ${this.resetTimeout}ms. Next retry allowed in ${this.resetTimeout}ms (${Math.round(this.resetTimeout / 1000)}s)`,
+          error instanceof Error ? error.stack : undefined,
           LogContext.COMMUNICATION
         );
         throw error;
@@ -148,6 +149,7 @@ export class PeekCircuitBreaker {
         this.logger.error?.(
           `Circuit breaker RE-OPENING from HALF_OPEN for room ${roomId} after failed test request. ` +
           `Previous state: ${previousState}. Next retry allowed in ${this.resetTimeout}ms (${Math.round(this.resetTimeout / 1000)}s)`,
+          error instanceof Error ? error.stack : undefined,
           LogContext.COMMUNICATION
         );
         throw error;
@@ -176,6 +178,7 @@ export class PeekCircuitBreaker {
         this.logger.error?.(
           `Circuit breaker OPENING for room ${roomId} - Failure threshold reached (${this.failureCount}/${this.failureThreshold}). ` +
           `Previous state: ${previousState}. Next retry allowed in ${this.resetTimeout}ms (${Math.round(this.resetTimeout / 1000)}s)`,
+          error instanceof Error ? error.stack : undefined,
           LogContext.COMMUNICATION
         );
       }


### PR DESCRIPTION
Enhances the peek circuit breaker to handle specific non-retryable errors, such as Matrix 403 errors when not in a room with previews disabled, by immediately opening the circuit and applying a max reset timeout.

Also, ensures circuit state is enforced before executing the function and re-opens the circuit immediately if the test request in HALF_OPEN state fails.

Opens the circuit as soon as the failure threshold is reached, independent of attempts.

Why failureCount exceeded the threshold:
- The circuit state was only checked when attempt > 1. If each peek starts with attempt=1, every call bypassed the OPEN check and hit Synapse.
- Opening the circuit required attempt >= maxAttempts AND failureCount >= failureThreshold. Across independent invocations (each starting at attempt=1), that condition rarely became true, so the breaker stayed CLOSED while failureCount kept incrementing.
- Concurrent peeks could also increment failureCount in parallel before any one call transitioned the state to OPEN.

What fixes the root cause (now implemented):
- Always enforce the circuit state at the start of each call.
- Open as soon as failureCount >= failureThreshold, independent of attempts.
- Treat 403 “not in room, previews disabled” as non-retryable and open immediately with max timeout.
- Re-open immediately if the HALF_OPEN test fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stops retries for non-retryable errors (e.g., access forbidden) so failures are reported immediately.
  * Enforces circuit protection before attempts to prevent cascading failures.
  * Opens circuit as soon as failure threshold is reached and re-opens to full block if HALF_OPEN test fails.
  * Improves error logging for clearer diagnostics and faster recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->