### PR TITLE
fix: change user namespace exclusivity to false. 

### DIFF
--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -43,7 +43,7 @@ func NewMautrixAdapter(cfg *config.Config, logger ports.Logger) (*MautrixAdapter
 		Namespaces: appservice.Namespaces{
 			UserIDs: []appservice.Namespace{
 				{
-					Exclusive: true,
+					Exclusive: false,
 					Regex:     "@[0-9a-fA-F-]{36}:.*",
 				},
 			},

--- a/registration.yaml
+++ b/registration.yaml
@@ -5,7 +5,7 @@ hs_token: secret_hs_token
 sender_localpart: alkemio-bot
 namespaces:
   users:
-    - exclusive: true
+    - exclusive: false
       regex: "@[0-9a-fA-F-]{36}:.*"
   aliases:
     - exclusive: true


### PR DESCRIPTION
This pull request updates the Matrix appservice configuration to change user namespace exclusivity from `true` to `false`. This adjustment allows other services or users to potentially use user IDs matching the specified regex pattern, rather than restricting them exclusively to this appservice.

Configuration changes:

* Set `Exclusive: false` for the user namespace in the `NewMautrixAdapter` constructor within `mautrix.go`, allowing non-exclusive handling of user IDs matching the regex.
* Updated `registration.yaml` to set `exclusive: false` for the user namespace, aligning the YAML configuration with the code change.…ned users to login on their own (via OIDC directly to Synapse).

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Modified app service user ID namespace matching behavior from exclusive to non-exclusive mode. This allows multiple services to handle overlapping user ID patterns, changing how user identities are routed within the service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->