### PR TITLE
  refactor(dto): standardize timestamps to int64 and add missing fields

### DIFF
--- a/internal/core/service/dm_service.go
+++ b/internal/core/service/dm_service.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -40,6 +41,7 @@ func (s *DMService) PublishDMRequest(initiatorActorID, targetActorID uuid.UUID) 
 	event := dto.DMRequestedEvent{
 		InitiatorActorID: initiatorActorID.String(),
 		TargetActorID:    targetActorID.String(),
+		Timestamp:        time.Now().UnixMilli(),
 	}
 
 	s.logger.Info("Publishing DM requested event",

--- a/internal/infrastructure/queue/handler_room.go
+++ b/internal/infrastructure/queue/handler_room.go
@@ -57,13 +57,23 @@ func (h *RoomHandler) resolveRoomAliasForBatch(ctx context.Context, alkemioRoomI
 // DTO Conversion Helpers (DRY principle - single source of truth)
 // ============================================================================
 
+// convertReactionToDTO converts a domain.Reaction to dto.ReactionDto.
+func convertReactionToDTO(r domain.Reaction) dto.ReactionDto {
+	return dto.ReactionDto{
+		ID:            dto.ReactionID(r.ID.String()),
+		Emoji:         r.Emoji,
+		SenderActorID: dto.AlkemioActorID(r.SenderID),
+		Timestamp:     r.Timestamp.UnixMilli(),
+	}
+}
+
 // convertMessageToDTO converts a domain.Message to dto.MessageDto.
 func convertMessageToDTO(msg domain.Message) dto.MessageDto {
 	msgDTO := dto.MessageDto{
 		ID:            dto.MessageID(msg.ID),
 		Content:       msg.Content,
 		SenderActorID: dto.AlkemioActorID(msg.SenderID),
-		Timestamp:     msg.Timestamp,
+		Timestamp:     msg.Timestamp.UnixMilli(),
 	}
 	// Set ThreadID if present
 	if msg.ThreadID != "" {
@@ -72,13 +82,7 @@ func convertMessageToDTO(msg domain.Message) dto.MessageDto {
 	}
 	// Convert reactions
 	for _, r := range msg.Reactions {
-		reactionDTO := dto.ReactionDto{
-			ID:            dto.ReactionID(r.ID.String()),
-			Emoji:         r.Emoji,
-			SenderActorID: dto.AlkemioActorID(r.SenderID),
-			Timestamp:     r.Timestamp,
-		}
-		msgDTO.Reactions = append(msgDTO.Reactions, reactionDTO)
+		msgDTO.Reactions = append(msgDTO.Reactions, convertReactionToDTO(r))
 	}
 	return msgDTO
 }
@@ -338,7 +342,7 @@ func (h *RoomHandler) HandleSendMessage(ctx context.Context, payload []byte) (in
 	return dto.SendMessageResponse{
 		BaseResponse: dto.NewSuccessResponse(),
 		MessageID:    dto.MessageID(eventID.String()),
-		Timestamp:    time.Now().UTC(),
+		Timestamp:    time.Now().UnixMilli(),
 	}, nil
 }
 
@@ -453,6 +457,7 @@ func (h *RoomHandler) HandleAddReaction(ctx context.Context, payload []byte) (in
 	return dto.AddReactionResponse{
 		BaseResponse: dto.NewSuccessResponse(),
 		ReactionID:   dto.ReactionID(eventID.String()),
+		Timestamp:    time.Now().UnixMilli(),
 	}, nil
 }
 
@@ -523,23 +528,16 @@ func (h *RoomHandler) HandleGetReaction(ctx context.Context, payload []byte) (in
 		return NewReactionNotFoundError(string(req.ReactionID)), nil
 	}
 
-	// Convert SenderMatrixID to SenderID (Alkemio actor UUID) using context-aware method
-	if reaction.SenderMatrixID != "" {
+	// Resolve SenderMatrixID to SenderID (Alkemio actor UUID) if needed
+	if reaction.SenderMatrixID != "" && reaction.SenderID == uuid.Nil {
 		if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, reaction.SenderMatrixID); err == nil {
 			reaction.SenderID = actorID
 		}
 	}
 
-	reactionDTO := dto.ReactionDto{
-		ID:            dto.ReactionID(reaction.ID.String()),
-		Emoji:         reaction.Emoji,
-		SenderActorID: dto.AlkemioActorID(reaction.SenderID),
-		Timestamp:     reaction.Timestamp,
-	}
-
 	return dto.GetReactionResponse{
 		BaseResponse: dto.NewSuccessResponse(),
-		Reaction:     reactionDTO,
+		Reaction:     convertReactionToDTO(*reaction),
 	}, nil
 }
 
@@ -697,31 +695,14 @@ func (h *RoomHandler) HandleGetThreadMessages(ctx context.Context, payload []byt
 
 	// Convert domain messages to DTOs
 	messageDTOs := make([]dto.MessageDto, 0, len(messages))
-	for _, msg := range messages {
-		// Convert sender Matrix ID to Alkemio actor ID using context-aware method
-		senderActorID := uuid.Nil
-		if msg.SenderMatrixID != "" {
-			if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, msg.SenderMatrixID); err == nil {
-				senderActorID = actorID
+	for i := range messages {
+		// Resolve sender Matrix ID to Alkemio actor ID if needed
+		if messages[i].SenderMatrixID != "" && messages[i].SenderID == uuid.Nil {
+			if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, messages[i].SenderMatrixID); err == nil {
+				messages[i].SenderID = actorID
 			}
-		} else if msg.SenderID != uuid.Nil {
-			senderActorID = msg.SenderID
 		}
-
-		msgDTO := dto.MessageDto{
-			ID:            dto.MessageID(msg.ID),
-			Content:       msg.Content,
-			SenderActorID: dto.AlkemioActorID(senderActorID),
-			Timestamp:     msg.Timestamp,
-		}
-
-		// Set thread ID if present (for replies within the thread)
-		if msg.ThreadID != "" {
-			threadID := dto.MessageID(msg.ThreadID)
-			msgDTO.ThreadID = &threadID
-		}
-
-		messageDTOs = append(messageDTOs, msgDTO)
+		messageDTOs = append(messageDTOs, convertMessageToDTO(messages[i]))
 	}
 
 	return dto.GetThreadMessagesResponse{

--- a/internal/infrastructure/queue/handler_space.go
+++ b/internal/infrastructure/queue/handler_space.go
@@ -91,10 +91,7 @@ func (h *SpaceHandler) HandleGetSpace(ctx context.Context, payload []byte) (inte
 	}
 
 	// Convert domain members to DTO
-	memberActorIDs := make([]dto.AlkemioActorID, 0, len(space.MemberIDs))
-	for _, memberID := range space.MemberIDs {
-		memberActorIDs = append(memberActorIDs, dto.AlkemioActorID(memberID))
-	}
+	memberActorIDs := convertMemberIDsToDTO(space.MemberIDs)
 
 	// Convert domain children to DTO
 	children := make([]dto.SpaceChildDto, 0, len(space.Children))

--- a/lib/src/dto/generated.ts
+++ b/lib/src/dto/generated.ts
@@ -232,6 +232,11 @@ export interface DMRequestedEvent {
    * TargetActorID is the Alkemio UUID of the user who is being invited to the DM.
    */
   target_actor_id: string;
+  /**
+   * Timestamp is when the adapter received the DM request webhook (Unix milliseconds).
+   * This is set locally by the adapter, representing when the request was processed.
+   */
+  timestamp: number /* int64 */;
 }
 /**
  * DMWebhookPayload represents the payload received from Synapse's DM request webhook.
@@ -406,7 +411,7 @@ export interface MessageDto {
   id: MessageID;
   content: string;
   sender_actor_id: AlkemioActorID;
-  timestamp: string;
+  timestamp: number /* int64 */; // Unix milliseconds
   reactions: ReactionDto[];
   thread_id?: MessageID;
 }
@@ -425,7 +430,13 @@ export interface SendMessageRequest {
  */
 export interface SendMessageResponse extends BaseResponse {
   message_id: MessageID;
-  timestamp: string; // UTC time from Matrix
+  /**
+   * Timestamp is the approximate creation time (Unix milliseconds).
+   * Note: This is set locally when the adapter receives confirmation from Matrix,
+   * not the exact server timestamp. The difference should be negligible (<100ms)
+   * assuming synchronized clocks (NTP).
+   */
+  timestamp: number /* int64 */;
 }
 /**
  * GetMessageRequest retrieves details of a specific message.
@@ -478,7 +489,7 @@ export interface ReactionDto {
   id: ReactionID;
   emoji: string;
   sender_actor_id: AlkemioActorID;
-  timestamp: string;
+  timestamp: number /* int64 */; // Unix milliseconds
 }
 /**
  * AddReactionRequest adds an emoji reaction to a message.
@@ -491,10 +502,17 @@ export interface AddReactionRequest {
   emoji: string;
 }
 /**
- * AddReactionResponse returns the reaction ID.
+ * AddReactionResponse returns the reaction ID and timestamp.
  */
 export interface AddReactionResponse extends BaseResponse {
   reaction_id: ReactionID;
+  /**
+   * Timestamp is the approximate creation time (Unix milliseconds).
+   * Note: This is set locally when the adapter receives confirmation from Matrix,
+   * not the exact server timestamp. The difference should be negligible (<100ms)
+   * assuming synchronized clocks (NTP).
+   */
+  timestamp: number /* int64 */;
 }
 /**
  * RemoveReactionRequest removes a previously added reaction.

--- a/pkg/dto/dm.go
+++ b/pkg/dto/dm.go
@@ -13,6 +13,9 @@ type DMRequestedEvent struct {
 	InitiatorActorID string `json:"initiator_actor_id"`
 	// TargetActorID is the Alkemio UUID of the user who is being invited to the DM.
 	TargetActorID string `json:"target_actor_id"`
+	// Timestamp is when the adapter received the DM request webhook (Unix milliseconds).
+	// This is set locally by the adapter, representing when the request was processed.
+	Timestamp int64 `json:"timestamp"`
 }
 
 // DMWebhookPayload represents the payload received from Synapse's DM request webhook.

--- a/pkg/dto/message.go
+++ b/pkg/dto/message.go
@@ -1,7 +1,5 @@
 package dto
 
-import "time"
-
 // ============================================================================
 // New Protocol DTOs (communication.message.*)
 // ============================================================================
@@ -11,7 +9,7 @@ type MessageDto struct {
 	ID            MessageID      `json:"id"`
 	Content       string         `json:"content"`
 	SenderActorID AlkemioActorID `json:"sender_actor_id"`
-	Timestamp     time.Time      `json:"timestamp"`
+	Timestamp     int64          `json:"timestamp"` // Unix milliseconds
 	Reactions     []ReactionDto  `json:"reactions"`
 	ThreadID      *MessageID     `json:"thread_id,omitempty"`
 }
@@ -29,7 +27,11 @@ type SendMessageRequest struct {
 type SendMessageResponse struct {
 	BaseResponse `tstype:",extends"`
 	MessageID    MessageID `json:"message_id"`
-	Timestamp    time.Time `json:"timestamp"` // UTC time from Matrix
+	// Timestamp is the approximate creation time (Unix milliseconds).
+	// Note: This is set locally when the adapter receives confirmation from Matrix,
+	// not the exact server timestamp. The difference should be negligible (<100ms)
+	// assuming synchronized clocks (NTP).
+	Timestamp int64 `json:"timestamp"`
 }
 
 // GetMessageRequest retrieves details of a specific message.

--- a/pkg/dto/reaction.go
+++ b/pkg/dto/reaction.go
@@ -1,7 +1,5 @@
 package dto
 
-import "time"
-
 // ============================================================================
 // New Protocol DTOs (communication.reaction.*)
 // ============================================================================
@@ -11,7 +9,7 @@ type ReactionDto struct {
 	ID            ReactionID     `json:"id"`
 	Emoji         string         `json:"emoji"`
 	SenderActorID AlkemioActorID `json:"sender_actor_id"`
-	Timestamp     time.Time      `json:"timestamp"`
+	Timestamp     int64          `json:"timestamp"` // Unix milliseconds
 }
 
 // AddReactionRequest adds an emoji reaction to a message.
@@ -23,10 +21,15 @@ type AddReactionRequest struct {
 	Emoji         string         `json:"emoji"`
 }
 
-// AddReactionResponse returns the reaction ID.
+// AddReactionResponse returns the reaction ID and timestamp.
 type AddReactionResponse struct {
 	BaseResponse `tstype:",extends"`
 	ReactionID   ReactionID `json:"reaction_id"`
+	// Timestamp is the approximate creation time (Unix milliseconds).
+	// Note: This is set locally when the adapter receives confirmation from Matrix,
+	// not the exact server timestamp. The difference should be negligible (<100ms)
+	// assuming synchronized clocks (NTP).
+	Timestamp int64 `json:"timestamp"`
 }
 
 // RemoveReactionRequest removes a previously added reaction.


### PR DESCRIPTION
  BREAKING CHANGE: All timestamp fields changed from time.Time (ISO 8601 string)
  to int64 (Unix milliseconds) for consistency with TypeScript consumers.

  Changes:
  - Standardize all DTO timestamps to int64 (Unix milliseconds)
    - MessageDto.Timestamp
    - ReactionDto.Timestamp
    - SendMessageResponse.Timestamp
  - Add missing Timestamp field to AddReactionResponse
  - Add missing Timestamp field to DMRequestedEvent
  - Add convertReactionToDTO helper for DRY compliance
  - Refactor HandleGetThreadMessages to use convertMessageToDTO helper
  - Refactor HandleGetReaction to use convertReactionToDTO helper
  - Document approximate timestamps in send responses (local time, not server)

  TypeScript consumers now have uniform timestamp handling:
    const date = new Date(response.timestamp)

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized timestamps across messaging and reaction APIs to Unix milliseconds (numeric).
  * Added timestamp fields to direct message requests, message creation responses, and reaction responses for clearer event timing.
  * Unified DTOs and responses to return numeric timestamps for messages and reactions for consistent client handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->