### PR TITLE
  feat: add batch query commands for unread counts and last messages

### DIFF
--- a/internal/core/ports/matrix.go
+++ b/internal/core/ports/matrix.go
@@ -58,6 +58,9 @@ type MatrixPort interface {
 	GetMessage(ctx context.Context, roomID id.RoomID, eventID id.EventID) (*domain.Message, error)
 	// GetRoomMessages retrieves all messages from a room.
 	GetRoomMessages(ctx context.Context, roomID id.RoomID) ([]domain.Message, error)
+	// GetLastMessage retrieves the most recent message in a room.
+	// Returns nil if the room has no messages.
+	GetLastMessage(ctx context.Context, roomID id.RoomID) (*domain.Message, error)
 	// GetReactionEventID finds the event ID of a specific reaction by a user.
 	GetReactionEventID(
 		ctx context.Context, roomID id.RoomID, eventID id.EventID, emoji string, senderID domain.Actor,

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -79,6 +79,7 @@ func NewMautrixAdapter(cfg *config.Config, logger ports.Logger) (*MautrixAdapter
 		AppToken:        cfg.Matrix.AppServiceToken,
 		ServerToken:     cfg.Matrix.HomeserverToken,
 		SenderLocalpart: botLocalpart,
+		EphemeralEvents: true, // Enable receiving ephemeral events (m.receipt for read receipts)
 		Namespaces: appservice.Namespaces{
 			UserIDs: []appservice.Namespace{
 				{
@@ -740,6 +741,132 @@ func (m *MautrixAdapter) GetRoomMessages(ctx context.Context, roomID id.RoomID) 
 	}
 
 	return messages, nil
+}
+
+// lastMessageStats tracks how many events were needed to find the last message.
+// Used for observability and future optimization of batch sizes.
+type lastMessageStats struct {
+	sync.Mutex
+	// Histogram buckets: events needed to find message (0-5, 6-10, 11-20, 21-50, 51-200, not found)
+	bucket5     int64
+	bucket10    int64
+	bucket20    int64
+	bucket50    int64
+	bucket200   int64
+	notFound    int64
+	totalCalls  int64
+	logInterval int64
+}
+
+var lastMsgStats = &lastMessageStats{logInterval: 100}
+
+func (s *lastMessageStats) record(eventsNeeded int, found bool, logger ports.Logger) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.totalCalls++
+
+	switch {
+	case !found:
+		s.notFound++
+	case eventsNeeded <= 5:
+		s.bucket5++
+	case eventsNeeded <= 10:
+		s.bucket10++
+	case eventsNeeded <= 20:
+		s.bucket20++
+	case eventsNeeded <= 50:
+		s.bucket50++
+	default:
+		s.bucket200++
+	}
+
+	// Log stats periodically
+	if s.totalCalls%s.logInterval == 0 {
+		logger.Info("GetLastMessage stats",
+			"total_calls", s.totalCalls,
+			"bucket_0-5", s.bucket5,
+			"bucket_6-10", s.bucket10,
+			"bucket_11-20", s.bucket20,
+			"bucket_21-50", s.bucket50,
+			"bucket_51-200", s.bucket200,
+			"not_found", s.notFound,
+		)
+	}
+}
+
+// GetLastMessage retrieves the most recent message in a room.
+// Returns nil if the room has no messages.
+func (m *MautrixAdapter) GetLastMessage(ctx context.Context, roomID id.RoomID) (*domain.Message, error) {
+	intent := m.as.BotIntent()
+
+	// Progressive fetch: start small, expand if needed
+	// In most cases, the last message is within the first few events
+	batchSizes := []int{5, 10, 20, 50, 200}
+	var allEvents []*event.Event
+	var from string
+
+	for _, batchSize := range batchSizes {
+		resp, err := intent.Messages(ctx, roomID, from, "", mautrix.DirectionBackward, nil, batchSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get last message: %w", err)
+		}
+
+		allEvents = append(allEvents, resp.Chunk...)
+
+		// Check if we found a message in this batch
+		for i, evt := range resp.Chunk {
+			if evt.Type == event.EventMessage {
+				// Record stats: total events scanned = previous batches + position in current batch
+				eventsScanned := len(allEvents) - len(resp.Chunk) + i + 1
+				lastMsgStats.record(eventsScanned, true, m.logger)
+				// Found a message - collect reactions from all fetched events and return
+				return m.buildLastMessageWithReactions(allEvents, roomID)
+			}
+		}
+
+		// No message found yet - continue with next batch if there are more events
+		if resp.End == "" || len(resp.Chunk) < batchSize {
+			break // No more events to fetch
+		}
+		from = resp.End
+	}
+
+	lastMsgStats.record(len(allEvents), false, m.logger)
+	return nil, nil // No messages in room
+}
+
+// buildLastMessageWithReactions finds the last message and attaches its reactions.
+func (m *MautrixAdapter) buildLastMessageWithReactions(events []*event.Event, roomID id.RoomID) (*domain.Message, error) {
+	// Find the first m.room.message event
+	var msg *domain.Message
+	for _, evt := range events {
+		if evt.Type == event.EventMessage {
+			msg = m.parseMessageEvent(evt, roomID)
+			if msg != nil {
+				msg.Reactions = []domain.Reaction{}
+				break
+			}
+		}
+	}
+
+	if msg == nil {
+		return nil, nil
+	}
+
+	// Collect reactions for this message
+	for _, evt := range events {
+		if evt.Type != event.EventReaction {
+			continue
+		}
+
+		reaction := m.parseReactionEvent(evt, roomID)
+		if reaction != nil && reaction.MessageID.String() == msg.ID {
+			msg.Reactions = append(msg.Reactions, *reaction)
+		}
+	}
+
+	return msg, nil
 }
 
 // parseReactionEvent extracts a domain.Reaction from a Matrix reaction event.

--- a/internal/infrastructure/queue/handler_read_receipt.go
+++ b/internal/infrastructure/queue/handler_read_receipt.go
@@ -133,6 +133,50 @@ func (h *ReadReceiptHandler) HandleGetUnreadCounts(ctx context.Context, payload 
 	}, nil
 }
 
+// HandleBatchGetUnreadCounts handles the communication.room.batch.unread_counts.get topic.
+func (h *ReadReceiptHandler) HandleBatchGetUnreadCounts(ctx context.Context, payload []byte) (interface{}, error) {
+	var req dto.BatchGetUnreadCountsRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return NewInvalidPayloadError(err), nil
+	}
+
+	// Validate required fields
+	if errResp := RequireUUID(req.ActorID, "actor_id"); errResp != nil {
+		return *errResp, nil
+	}
+	if len(req.AlkemioRoomIDs) == 0 {
+		return NewInvalidParamError("alkemio_room_ids is required"), nil
+	}
+
+	unreadCounts := make(map[string]int)
+	errors := make(map[string]dto.BaseResponse)
+
+	for _, alkemioRoomID := range req.AlkemioRoomIDs {
+		roomID, errResp := h.resolveRoomAlias(ctx, alkemioRoomID)
+		if errResp != nil {
+			errors[alkemioRoomID.String()] = *errResp
+			continue
+		}
+
+		summary, err := h.service.GetUnreadCounts(ctx, req.ActorID.UUID(), roomID, nil)
+		if err != nil {
+			errors[alkemioRoomID.String()] = MapServiceError(err)
+			continue
+		}
+
+		unreadCounts[alkemioRoomID.String()] = summary.RoomUnreadCount
+	}
+
+	resp := dto.BatchGetUnreadCountsResponse{
+		BaseResponse: dto.NewSuccessResponse(),
+		UnreadCounts: unreadCounts,
+	}
+	if len(errors) > 0 {
+		resp.Errors = errors
+	}
+	return resp, nil
+}
+
 // resolveRoomAlias resolves an Alkemio room ID to a Matrix room ID.
 func (h *ReadReceiptHandler) resolveRoomAlias(ctx context.Context, alkemioRoomID dto.AlkemioRoomID) (id.RoomID, *dto.BaseResponse) {
 	alias := h.idMapper.RoomAlias(alkemioRoomID.UUID())

--- a/internal/infrastructure/queue/handler_room.go
+++ b/internal/infrastructure/queue/handler_room.go
@@ -53,6 +53,19 @@ func (h *RoomHandler) resolveRoomAliasForBatch(ctx context.Context, alkemioRoomI
 	return roomID, nil
 }
 
+// resolveSenderID resolves a Matrix user ID to an Alkemio actor UUID.
+// Returns uuid.Nil if the matrix ID is empty or resolution fails.
+func (h *RoomHandler) resolveSenderID(ctx context.Context, matrixID string) uuid.UUID {
+	if matrixID == "" {
+		return uuid.Nil
+	}
+	actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, matrixID)
+	if err != nil {
+		return uuid.Nil
+	}
+	return actorID
+}
+
 // ============================================================================
 // DTO Conversion Helpers (DRY principle - single source of truth)
 // ============================================================================
@@ -529,10 +542,8 @@ func (h *RoomHandler) HandleGetReaction(ctx context.Context, payload []byte) (in
 	}
 
 	// Resolve SenderMatrixID to SenderID (Alkemio actor UUID) if needed
-	if reaction.SenderMatrixID != "" && reaction.SenderID == uuid.Nil {
-		if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, reaction.SenderMatrixID); err == nil {
-			reaction.SenderID = actorID
-		}
+	if reaction.SenderID == uuid.Nil {
+		reaction.SenderID = h.resolveSenderID(ctx, reaction.SenderMatrixID)
 	}
 
 	return dto.GetReactionResponse{
@@ -697,10 +708,8 @@ func (h *RoomHandler) HandleGetThreadMessages(ctx context.Context, payload []byt
 	messageDTOs := make([]dto.MessageDto, 0, len(messages))
 	for i := range messages {
 		// Resolve sender Matrix ID to Alkemio actor ID if needed
-		if messages[i].SenderMatrixID != "" && messages[i].SenderID == uuid.Nil {
-			if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, messages[i].SenderMatrixID); err == nil {
-				messages[i].SenderID = actorID
-			}
+		if messages[i].SenderID == uuid.Nil {
+			messages[i].SenderID = h.resolveSenderID(ctx, messages[i].SenderMatrixID)
 		}
 		messageDTOs = append(messageDTOs, convertMessageToDTO(messages[i]))
 	}
@@ -740,11 +749,9 @@ func (h *RoomHandler) HandleGetLastMessage(ctx context.Context, payload []byte) 
 
 	var msgDTO *dto.MessageDto
 	if msg != nil {
-		// Resolve sender Matrix ID to Alkemio actor ID
-		if msg.SenderMatrixID != "" && msg.SenderID == uuid.Nil {
-			if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, msg.SenderMatrixID); err == nil {
-				msg.SenderID = actorID
-			}
+		// Resolve sender Matrix ID to Alkemio actor ID if needed
+		if msg.SenderID == uuid.Nil {
+			msg.SenderID = h.resolveSenderID(ctx, msg.SenderMatrixID)
 		}
 		converted := convertMessageToDTO(*msg)
 		msgDTO = &converted
@@ -785,11 +792,9 @@ func (h *RoomHandler) HandleBatchGetLastMessages(ctx context.Context, payload []
 
 		var msgDTO *dto.MessageDto
 		if msg != nil {
-			// Resolve sender Matrix ID to Alkemio actor ID
-			if msg.SenderMatrixID != "" && msg.SenderID == uuid.Nil {
-				if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, msg.SenderMatrixID); err == nil {
-					msg.SenderID = actorID
-				}
+			// Resolve sender Matrix ID to Alkemio actor ID if needed
+			if msg.SenderID == uuid.Nil {
+				msg.SenderID = h.resolveSenderID(ctx, msg.SenderMatrixID)
 			}
 			converted := convertMessageToDTO(*msg)
 			msgDTO = &converted

--- a/internal/infrastructure/queue/handler_room.go
+++ b/internal/infrastructure/queue/handler_room.go
@@ -712,3 +712,97 @@ func (h *RoomHandler) HandleGetThreadMessages(ctx context.Context, payload []byt
 		Messages:      messageDTOs,
 	}, nil
 }
+
+// ============================================================================
+// Last Message Handlers (communication.room.last_message.*, communication.room.batch.last_messages.*)
+// ============================================================================
+
+// HandleGetLastMessage handles communication.room.last_message.get topic.
+func (h *RoomHandler) HandleGetLastMessage(ctx context.Context, payload []byte) (interface{}, error) {
+	var req dto.GetLastMessageRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return NewInvalidPayloadError(err), nil
+	}
+
+	if errResp := RequireUUID(req.AlkemioRoomID, "alkemio_room_id"); errResp != nil {
+		return *errResp, nil
+	}
+
+	roomID, errResp := h.resolveRoomAlias(ctx, req.AlkemioRoomID)
+	if errResp != nil {
+		return *errResp, nil
+	}
+
+	msg, err := h.matrix.GetLastMessage(ctx, roomID)
+	if err != nil {
+		return MapServiceError(err), nil
+	}
+
+	var msgDTO *dto.MessageDto
+	if msg != nil {
+		// Resolve sender Matrix ID to Alkemio actor ID
+		if msg.SenderMatrixID != "" && msg.SenderID == uuid.Nil {
+			if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, msg.SenderMatrixID); err == nil {
+				msg.SenderID = actorID
+			}
+		}
+		converted := convertMessageToDTO(*msg)
+		msgDTO = &converted
+	}
+
+	return dto.GetLastMessageResponse{
+		BaseResponse: dto.NewSuccessResponse(),
+		Message:      msgDTO,
+	}, nil
+}
+
+// HandleBatchGetLastMessages handles communication.room.batch.last_messages.get topic.
+func (h *RoomHandler) HandleBatchGetLastMessages(ctx context.Context, payload []byte) (interface{}, error) {
+	var req dto.BatchGetLastMessagesRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return NewInvalidPayloadError(err), nil
+	}
+
+	if len(req.AlkemioRoomIDs) == 0 {
+		return NewInvalidParamError("alkemio_room_ids is required"), nil
+	}
+
+	messages := make(map[string]*dto.MessageDto)
+	errors := make(map[string]dto.BaseResponse)
+
+	for _, alkemioRoomID := range req.AlkemioRoomIDs {
+		roomID, err := h.resolveRoomAliasForBatch(ctx, alkemioRoomID)
+		if err != nil {
+			errors[alkemioRoomID.String()] = MapToBatchResult(err)
+			continue
+		}
+
+		msg, err := h.matrix.GetLastMessage(ctx, roomID)
+		if err != nil {
+			errors[alkemioRoomID.String()] = MapToBatchResult(err)
+			continue
+		}
+
+		var msgDTO *dto.MessageDto
+		if msg != nil {
+			// Resolve sender Matrix ID to Alkemio actor ID
+			if msg.SenderMatrixID != "" && msg.SenderID == uuid.Nil {
+				if actorID, err := h.idMapper.AlkemioActorIDWithContext(ctx, msg.SenderMatrixID); err == nil {
+					msg.SenderID = actorID
+				}
+			}
+			converted := convertMessageToDTO(*msg)
+			msgDTO = &converted
+		}
+		messages[alkemioRoomID.String()] = msgDTO
+	}
+
+	resp := dto.BatchGetLastMessagesResponse{
+		BaseResponse: dto.NewSuccessResponse(),
+		Messages:     messages,
+	}
+	if len(errors) > 0 {
+		resp.Errors = errors
+	}
+	return resp, nil
+}

--- a/internal/infrastructure/queue/router.go
+++ b/internal/infrastructure/queue/router.go
@@ -57,6 +57,11 @@ func RegisterRoutes(q ports.QueuePort, room *RoomHandler, actor *ActorHandler, s
 		// Read Receipt Routes (communication.message.read, communication.room.unread_counts.get)
 		TopicMessageRead:     readReceipt.HandleMarkMessageRead,
 		TopicUnreadCountsGet: readReceipt.HandleGetUnreadCounts,
+
+		// Batch Query Routes (communication.room.batch.*, communication.room.last_message.*)
+		TopicBatchUnreadCountsGet: readReceipt.HandleBatchGetUnreadCounts,
+		TopicLastMessageGet:       room.HandleGetLastMessage,
+		TopicBatchLastMessagesGet: room.HandleBatchGetLastMessages,
 	}
 
 	for topic, handler := range routes {

--- a/internal/infrastructure/queue/topics.go
+++ b/internal/infrastructure/queue/topics.go
@@ -77,6 +77,14 @@ const (
 	// TopicUnreadCountsGet is the topic for getting unread counts.
 	TopicUnreadCountsGet = dto.TopicUnreadCountsGet
 
+	// Batch Query Command Topics
+	// TopicBatchUnreadCountsGet is the topic for getting unread counts for multiple rooms.
+	TopicBatchUnreadCountsGet = dto.TopicBatchUnreadCountsGet
+	// TopicLastMessageGet is the topic for getting the last message in a room.
+	TopicLastMessageGet = dto.TopicLastMessageGet
+	// TopicBatchLastMessagesGet is the topic for getting last messages for multiple rooms.
+	TopicBatchLastMessagesGet = dto.TopicBatchLastMessagesGet
+
 	// Read Receipt & Message Event Topics (008-read-receipts outgoing)
 	// TopicReadReceiptUpdated is the topic for read receipt update events.
 	TopicReadReceiptUpdated = dto.TopicReadReceiptUpdated

--- a/pkg/dto/batch.go
+++ b/pkg/dto/batch.go
@@ -32,3 +32,55 @@ type BatchRemoveMemberResponse struct {
 	BaseResponse `tstype:",extends"`
 	Results      map[string]BaseResponse `json:"results,omitempty"`
 }
+
+// ============================================================================
+// Batch Unread Counts DTOs (communication.room.batch.unread_counts.*)
+// ============================================================================
+
+// BatchGetUnreadCountsRequest gets unread counts for multiple rooms.
+// Topic: communication.room.batch.unread_counts.get
+type BatchGetUnreadCountsRequest struct {
+	ActorID        AlkemioActorID  `json:"actor_id"`
+	AlkemioRoomIDs []AlkemioRoomID `json:"alkemio_room_ids"`
+}
+
+// BatchGetUnreadCountsResponse returns per-room unread counts.
+type BatchGetUnreadCountsResponse struct {
+	BaseResponse `tstype:",extends"`
+	// UnreadCounts maps AlkemioRoomID (string) to unread count.
+	// Rooms with errors will not be included in the map.
+	UnreadCounts map[string]int `json:"unread_counts"`
+	// Errors maps AlkemioRoomID (string) to error response for failed rooms.
+	Errors map[string]BaseResponse `json:"errors,omitempty"`
+}
+
+// ============================================================================
+// Last Message DTOs (communication.room.last_message.*, communication.room.batch.last_messages.*)
+// ============================================================================
+
+// GetLastMessageRequest gets the most recent message in a room.
+// Topic: communication.room.last_message.get
+type GetLastMessageRequest struct {
+	AlkemioRoomID AlkemioRoomID `json:"alkemio_room_id"`
+}
+
+// GetLastMessageResponse returns the last message or null if room is empty.
+type GetLastMessageResponse struct {
+	BaseResponse `tstype:",extends"`
+	Message      *MessageDto `json:"message"` // nil if no messages
+}
+
+// BatchGetLastMessagesRequest gets the most recent message for multiple rooms.
+// Topic: communication.room.batch.last_messages.get
+type BatchGetLastMessagesRequest struct {
+	AlkemioRoomIDs []AlkemioRoomID `json:"alkemio_room_ids"`
+}
+
+// BatchGetLastMessagesResponse returns per-room last messages.
+type BatchGetLastMessagesResponse struct {
+	BaseResponse `tstype:",extends"`
+	// Messages maps AlkemioRoomID (string) to last message (null if empty room).
+	Messages map[string]*MessageDto `json:"messages"`
+	// Errors maps AlkemioRoomID (string) to error response for failed rooms.
+	Errors map[string]BaseResponse `json:"errors,omitempty"`
+}

--- a/pkg/dto/commands.go
+++ b/pkg/dto/commands.go
@@ -85,6 +85,16 @@ const (
 	TopicUnreadCountsGet = "communication.room.unread_counts.get"
 )
 
+// Batch Query Command Topics (Server → Adapter)
+const (
+	// TopicBatchUnreadCountsGet is the topic for getting unread counts for multiple rooms.
+	TopicBatchUnreadCountsGet = "communication.room.batch.unread_counts.get"
+	// TopicLastMessageGet is the topic for getting the last message in a room.
+	TopicLastMessageGet = "communication.room.last_message.get"
+	// TopicBatchLastMessagesGet is the topic for getting last messages for multiple rooms.
+	TopicBatchLastMessagesGet = "communication.room.batch.last_messages.get"
+)
+
 // Read Receipt & Message Event Topics (Adapter → Server)
 const (
 	// TopicReadReceiptUpdated is the topic for read receipt update events.
@@ -164,6 +174,11 @@ var CommandRegistry = []CommandDef{
 	// Read Receipt commands
 	{Topic: TopicMessageRead, RequestType: "MarkMessageReadRequest", ResponseType: "BaseResponse"},
 	{Topic: TopicUnreadCountsGet, RequestType: "GetUnreadCountsRequest", ResponseType: "GetUnreadCountsResponse"},
+
+	// Batch query commands
+	{Topic: TopicBatchUnreadCountsGet, RequestType: "BatchGetUnreadCountsRequest", ResponseType: "BatchGetUnreadCountsResponse"},
+	{Topic: TopicLastMessageGet, RequestType: "GetLastMessageRequest", ResponseType: "GetLastMessageResponse"},
+	{Topic: TopicBatchLastMessagesGet, RequestType: "BatchGetLastMessagesRequest", ResponseType: "BatchGetLastMessagesResponse"},
 }
 
 // OutgoingEventRegistry defines events emitted by the adapter (not commands).

--- a/registration.yaml
+++ b/registration.yaml
@@ -4,6 +4,8 @@ as_token: secret_as_token
 hs_token: secret_hs_token
 # Bot localpart must match MATRIX_BOT_ACTOR_ID (UUID format)
 sender_localpart: "00000000-0000-0000-0000-000000000000"
+# Enable receiving ephemeral events (m.receipt for read receipts)
+receive_ephemeral: true
 namespaces:
   users:
     # Bot user - exclusive, only AS can control (security: prevents impersonation)


### PR DESCRIPTION
  Add three new commands for efficient batch querying:
  - communication.room.batch.unread_counts.get - Get unread counts for multiple rooms
  - communication.room.last_message.get - Get last message for a single room
  - communication.room.batch.last_messages.get - Get last messages for multiple rooms

  Key changes:
  - Add 6 new DTOs (BatchGetUnreadCountsRequest/Response, GetLastMessageRequest/Response, BatchGetLastMessagesRequest/Response)
  - Add GetLastMessage to MatrixPort interface
  - Implement GetLastMessage with progressive fetch (5→10→20→50→200 events) to minimize data transfer while handling edge cases
  - Include reactions in last message response
  - Add histogram stats for GetLastMessage to track fetch efficiency (logs every 100 calls for future optimization)
  - Add HandleBatchGetUnreadCounts to read receipt handler
  - Add HandleGetLastMessage and HandleBatchGetLastMessages to room handler
  - Enable ephemeral events (receive_ephemeral: true) for read receipts

  Batch responses include separate 'errors' map for per-room failures,
  allowing partial success when some rooms fail.

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Retrieve the last message from a room (single-room API).
* Batch operations to fetch last messages for multiple rooms.
* Batch operation to fetch unread counts across multiple rooms.
* Enabled ephemeral events to improve receipt handling and message observation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->