### PR TITLE
feat: implement batch methods for fetching unread counts and last mes…

### DIFF
--- a/internal/core/ports/matrix.go
+++ b/internal/core/ports/matrix.go
@@ -61,6 +61,9 @@ type MatrixPort interface {
 	// GetLastMessage retrieves the most recent message in a room.
 	// Returns nil if the room has no messages.
 	GetLastMessage(ctx context.Context, roomID id.RoomID) (*domain.Message, error)
+	// GetBatchLastMessages retrieves the most recent message for multiple rooms in parallel.
+	// Returns a map of roomID to message (nil if no messages), and a map of roomIDs that had errors.
+	GetBatchLastMessages(ctx context.Context, roomIDs []id.RoomID) (map[id.RoomID]*domain.Message, map[id.RoomID]error)
 	// GetReactionEventID finds the event ID of a specific reaction by a user.
 	GetReactionEventID(
 		ctx context.Context, roomID id.RoomID, eventID id.EventID, emoji string, senderID domain.Actor,
@@ -124,4 +127,8 @@ type MatrixPort interface {
 	// GetUnreadCounts retrieves unread message counts for a room and optionally specific threads.
 	// Returns room-level unread count and per-thread unread counts for any specified threadRootIDs.
 	GetUnreadCounts(ctx context.Context, actorID domain.Actor, roomID id.RoomID, threadRootIDs []id.EventID) (*domain.UnreadCountSummary, error)
+
+	// GetBatchUnreadCounts retrieves unread counts for multiple rooms in a single sync call.
+	// Returns a map of roomID to unread count, and a map of roomIDs that had errors.
+	GetBatchUnreadCounts(ctx context.Context, actorID domain.Actor, roomIDs []id.RoomID) (map[id.RoomID]int, map[id.RoomID]error)
 }

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -869,8 +869,11 @@ func (m *MautrixAdapter) buildLastMessageWithReactions(events []*event.Event, ro
 	return msg, nil
 }
 
+// maxConcurrentLastMessageFetches limits parallel requests to avoid overwhelming the homeserver.
+const maxConcurrentLastMessageFetches = 10
+
 // GetBatchLastMessages retrieves the most recent message for multiple rooms in parallel.
-// This is more efficient than sequential calls as HTTP requests run concurrently.
+// Limits concurrency to avoid overwhelming the homeserver with too many simultaneous requests.
 func (m *MautrixAdapter) GetBatchLastMessages(
 	ctx context.Context, roomIDs []id.RoomID,
 ) (map[id.RoomID]*domain.Message, map[id.RoomID]error) {
@@ -889,12 +892,17 @@ func (m *MautrixAdapter) GetBatchLastMessages(
 	}
 	resultCh := make(chan result, len(roomIDs))
 
-	// Launch parallel goroutines for each room
+	// Semaphore to limit concurrent requests
+	sem := make(chan struct{}, maxConcurrentLastMessageFetches)
+
+	// Launch parallel goroutines for each room (bounded by semaphore)
 	var wg sync.WaitGroup
 	for _, roomID := range roomIDs {
 		wg.Add(1)
 		go func(rid id.RoomID) {
 			defer wg.Done()
+			sem <- struct{}{}        // Acquire semaphore
+			defer func() { <-sem }() // Release semaphore
 			msg, err := m.GetLastMessage(ctx, rid)
 			resultCh <- result{roomID: rid, msg: msg, err: err}
 		}(roomID)

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -869,6 +869,62 @@ func (m *MautrixAdapter) buildLastMessageWithReactions(events []*event.Event, ro
 	return msg, nil
 }
 
+// GetBatchLastMessages retrieves the most recent message for multiple rooms in parallel.
+// This is more efficient than sequential calls as HTTP requests run concurrently.
+func (m *MautrixAdapter) GetBatchLastMessages(
+	ctx context.Context, roomIDs []id.RoomID,
+) (map[id.RoomID]*domain.Message, map[id.RoomID]error) {
+	results := make(map[id.RoomID]*domain.Message)
+	errors := make(map[id.RoomID]error)
+
+	if len(roomIDs) == 0 {
+		return results, errors
+	}
+
+	// Use channels to collect results from goroutines
+	type result struct {
+		roomID id.RoomID
+		msg    *domain.Message
+		err    error
+	}
+	resultCh := make(chan result, len(roomIDs))
+
+	// Launch parallel goroutines for each room
+	var wg sync.WaitGroup
+	for _, roomID := range roomIDs {
+		wg.Add(1)
+		go func(rid id.RoomID) {
+			defer wg.Done()
+			msg, err := m.GetLastMessage(ctx, rid)
+			resultCh <- result{roomID: rid, msg: msg, err: err}
+		}(roomID)
+	}
+
+	// Close channel when all goroutines complete
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	// Collect results
+	for r := range resultCh {
+		if r.err != nil {
+			errors[r.roomID] = r.err
+		} else {
+			results[r.roomID] = r.msg
+		}
+	}
+
+	m.logger.Debug(
+		"Retrieved batch last messages",
+		"rooms_requested", len(roomIDs),
+		"rooms_found", len(results),
+		"rooms_failed", len(errors),
+	)
+
+	return results, errors
+}
+
 // parseReactionEvent extracts a domain.Reaction from a Matrix reaction event.
 func (m *MautrixAdapter) parseReactionEvent(evt *event.Event, roomID id.RoomID) *domain.Reaction {
 	content, ok := parseEventContent[event.ReactionEventContent](evt)
@@ -1640,4 +1696,108 @@ func (m *MautrixAdapter) GetUnreadCounts(
 	)
 
 	return summary, nil
+}
+
+// GetBatchUnreadCounts retrieves unread counts for multiple rooms in a single sync call.
+// This is more efficient than calling GetUnreadCounts for each room individually.
+func (m *MautrixAdapter) GetBatchUnreadCounts(
+	ctx context.Context, actor domain.Actor, roomIDs []id.RoomID,
+) (map[id.RoomID]int, map[id.RoomID]error) {
+	results := make(map[id.RoomID]int)
+	errors := make(map[id.RoomID]error)
+
+	if len(roomIDs) == 0 {
+		return results, errors
+	}
+
+	// Get the user's intent to make API calls as that user
+	userID, err := m.idMapper.UserID(ctx, actor.ID)
+	if err != nil {
+		m.logger.Error("Failed to resolve actor ID for batch unread", "error", err, "actor_id", actor.ID)
+		// Return error for all rooms
+		for _, roomID := range roomIDs {
+			errors[roomID] = fmt.Errorf("failed to resolve actor ID: %w", err)
+		}
+		return results, errors
+	}
+	intent := m.as.Intent(userID)
+
+	// Ensure the user is registered before making sync requests
+	if err := intent.EnsureRegistered(ctx); err != nil {
+		m.logger.Error("Failed to ensure user registered for batch unread", "error", err, "user_id", userID)
+		for _, roomID := range roomIDs {
+			errors[roomID] = fmt.Errorf("failed to ensure user registered: %w", err)
+		}
+		return results, errors
+	}
+
+	// Create a filter that includes ALL requested rooms to minimize HTTP calls.
+	// We only need the unread notification counts, not timeline events.
+	filter := &mautrix.Filter{
+		Room: &mautrix.RoomFilter{
+			Rooms: roomIDs, // All rooms in single filter
+			Timeline: &mautrix.FilterPart{
+				Limit: 0, // Don't fetch timeline events
+			},
+			State: &mautrix.FilterPart{
+				Limit: 0, // Don't fetch state events
+			},
+			Ephemeral: &mautrix.FilterPart{
+				Limit: 0, // Don't fetch ephemeral events
+			},
+		},
+		Presence: &mautrix.FilterPart{
+			Limit: 0, // Don't fetch presence
+		},
+	}
+
+	// Create the filter on the server
+	filterResp, err := intent.CreateFilter(ctx, filter)
+	if err != nil {
+		m.logger.Error("Failed to create batch sync filter", "error", err, "actor_id", actor.ID, "room_count", len(roomIDs))
+		for _, roomID := range roomIDs {
+			errors[roomID] = fmt.Errorf("failed to create sync filter: %w", err)
+		}
+		return results, errors
+	}
+
+	// Perform an initial sync (timeout=0) to get current state without blocking.
+	syncResp, err := intent.SyncRequest(ctx, 0, "", filterResp.FilterID, false, "")
+	if err != nil {
+		m.logger.Error("Failed to sync for batch unread counts", "error", err, "actor_id", actor.ID)
+		for _, roomID := range roomIDs {
+			errors[roomID] = fmt.Errorf("failed to sync: %w", err)
+		}
+		return results, errors
+	}
+
+	// Extract unread counts from the sync response for each room
+	for _, roomID := range roomIDs {
+		if joinedRoom, ok := syncResp.Rooms.Join[roomID]; ok {
+			count := 0
+			// Get standard notification count
+			if joinedRoom.UnreadNotifications != nil {
+				count = joinedRoom.UnreadNotifications.NotificationCount
+			}
+			// MSC2654 provides actual unread message count (prefer if available)
+			if joinedRoom.MSC2654UnreadCount != nil {
+				count = *joinedRoom.MSC2654UnreadCount
+			}
+			results[roomID] = count
+		} else {
+			// Room not present in sync response - user may not be joined
+			m.logger.Warn("Room not in sync response for batch unread", "room_id", roomID, "actor_id", actor.ID)
+			errors[roomID] = fmt.Errorf("room not found in sync response")
+		}
+	}
+
+	m.logger.Debug(
+		"Retrieved batch unread counts",
+		"actor_id", actor.ID,
+		"rooms_requested", len(roomIDs),
+		"rooms_found", len(results),
+		"rooms_failed", len(errors),
+	)
+
+	return results, errors
 }

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -901,8 +901,14 @@ func (m *MautrixAdapter) GetBatchLastMessages(
 		wg.Add(1)
 		go func(rid id.RoomID) {
 			defer wg.Done()
-			sem <- struct{}{}        // Acquire semaphore
-			defer func() { <-sem }() // Release semaphore
+			// Acquire semaphore with context awareness
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				resultCh <- result{roomID: rid, err: ctx.Err()}
+				return
+			}
 			msg, err := m.GetLastMessage(ctx, rid)
 			resultCh <- result{roomID: rid, msg: msg, err: err}
 		}(roomID)

--- a/internal/infrastructure/queue/handler_read_receipt.go
+++ b/internal/infrastructure/queue/handler_read_receipt.go
@@ -134,6 +134,7 @@ func (h *ReadReceiptHandler) HandleGetUnreadCounts(ctx context.Context, payload 
 }
 
 // HandleBatchGetUnreadCounts handles the communication.room.batch.unread_counts.get topic.
+// Uses a single Matrix sync call for all rooms for efficiency.
 func (h *ReadReceiptHandler) HandleBatchGetUnreadCounts(ctx context.Context, payload []byte) (interface{}, error) {
 	var req dto.BatchGetUnreadCountsRequest
 	if err := json.Unmarshal(payload, &req); err != nil {
@@ -148,7 +149,9 @@ func (h *ReadReceiptHandler) HandleBatchGetUnreadCounts(ctx context.Context, pay
 		return NewInvalidParamError("alkemio_room_ids is required"), nil
 	}
 
-	unreadCounts := make(map[string]int)
+	// First, resolve all room aliases to Matrix room IDs
+	matrixRoomIDs := make([]id.RoomID, 0, len(req.AlkemioRoomIDs))
+	alkemioToMatrix := make(map[id.RoomID]dto.AlkemioRoomID) // Reverse mapping
 	errors := make(map[string]dto.BaseResponse)
 
 	for _, alkemioRoomID := range req.AlkemioRoomIDs {
@@ -157,14 +160,23 @@ func (h *ReadReceiptHandler) HandleBatchGetUnreadCounts(ctx context.Context, pay
 			errors[alkemioRoomID.String()] = *errResp
 			continue
 		}
+		matrixRoomIDs = append(matrixRoomIDs, roomID)
+		alkemioToMatrix[roomID] = alkemioRoomID
+	}
 
-		summary, err := h.service.GetUnreadCounts(ctx, req.ActorID.UUID(), roomID, nil)
-		if err != nil {
-			errors[alkemioRoomID.String()] = MapServiceError(err)
-			continue
-		}
+	// Use efficient batch method - single sync for all rooms
+	actor := domain.Actor{ID: req.ActorID.UUID()}
+	batchResults, batchErrors := h.matrix.GetBatchUnreadCounts(ctx, actor, matrixRoomIDs)
 
-		unreadCounts[alkemioRoomID.String()] = summary.RoomUnreadCount
+	// Convert results back to Alkemio room IDs
+	unreadCounts := make(map[string]int)
+	for matrixRoomID, count := range batchResults {
+		alkemioRoomID := alkemioToMatrix[matrixRoomID]
+		unreadCounts[alkemioRoomID.String()] = count
+	}
+	for matrixRoomID, err := range batchErrors {
+		alkemioRoomID := alkemioToMatrix[matrixRoomID]
+		errors[alkemioRoomID.String()] = MapToBatchResult(err)
 	}
 
 	resp := dto.BatchGetUnreadCountsResponse{

--- a/internal/infrastructure/queue/handler_room.go
+++ b/internal/infrastructure/queue/handler_room.go
@@ -764,6 +764,7 @@ func (h *RoomHandler) HandleGetLastMessage(ctx context.Context, payload []byte) 
 }
 
 // HandleBatchGetLastMessages handles communication.room.batch.last_messages.get topic.
+// Uses parallel goroutines for efficient fetching from multiple rooms.
 func (h *RoomHandler) HandleBatchGetLastMessages(ctx context.Context, payload []byte) (interface{}, error) {
 	var req dto.BatchGetLastMessagesRequest
 	if err := json.Unmarshal(payload, &req); err != nil {
@@ -774,7 +775,9 @@ func (h *RoomHandler) HandleBatchGetLastMessages(ctx context.Context, payload []
 		return NewInvalidParamError("alkemio_room_ids is required"), nil
 	}
 
-	messages := make(map[string]*dto.MessageDto)
+	// First, resolve all room aliases to Matrix room IDs
+	matrixRoomIDs := make([]id.RoomID, 0, len(req.AlkemioRoomIDs))
+	alkemioToMatrix := make(map[id.RoomID]dto.AlkemioRoomID) // Reverse mapping
 	errors := make(map[string]dto.BaseResponse)
 
 	for _, alkemioRoomID := range req.AlkemioRoomIDs {
@@ -783,13 +786,17 @@ func (h *RoomHandler) HandleBatchGetLastMessages(ctx context.Context, payload []
 			errors[alkemioRoomID.String()] = MapToBatchResult(err)
 			continue
 		}
+		matrixRoomIDs = append(matrixRoomIDs, roomID)
+		alkemioToMatrix[roomID] = alkemioRoomID
+	}
 
-		msg, err := h.matrix.GetLastMessage(ctx, roomID)
-		if err != nil {
-			errors[alkemioRoomID.String()] = MapToBatchResult(err)
-			continue
-		}
+	// Use efficient batch method - parallel goroutines for all rooms
+	batchResults, batchErrors := h.matrix.GetBatchLastMessages(ctx, matrixRoomIDs)
 
+	// Convert results back to Alkemio room IDs
+	messages := make(map[string]*dto.MessageDto)
+	for matrixRoomID, msg := range batchResults {
+		alkemioRoomID := alkemioToMatrix[matrixRoomID]
 		var msgDTO *dto.MessageDto
 		if msg != nil {
 			// Resolve sender Matrix ID to Alkemio actor ID if needed
@@ -800,6 +807,10 @@ func (h *RoomHandler) HandleBatchGetLastMessages(ctx context.Context, payload []
 			msgDTO = &converted
 		}
 		messages[alkemioRoomID.String()] = msgDTO
+	}
+	for matrixRoomID, err := range batchErrors {
+		alkemioRoomID := alkemioToMatrix[matrixRoomID]
+		errors[alkemioRoomID.String()] = MapToBatchResult(err)
 	}
 
 	resp := dto.BatchGetLastMessagesResponse{


### PR DESCRIPTION
This pull request introduces efficient batch operations for fetching the latest messages and unread counts across multiple Matrix rooms. The main improvements are the addition of parallelized and single-request batch methods in the Matrix adapter and refactoring of queue handlers to use these new methods, reducing latency and resource usage for bulk operations.

**Batch operations for Matrix rooms:**

* Added `GetBatchLastMessages` and `GetBatchUnreadCounts` methods to the `MatrixPort` interface to support efficient retrieval of last messages and unread counts for multiple rooms in parallel or with a single sync call. [[1]](diffhunk://#diff-a1b7fba9d5504c6ae5db8d8d99e52082ea11ee90370d56cce2f5548a5610c2d6R64-R66) [[2]](diffhunk://#diff-a1b7fba9d5504c6ae5db8d8d99e52082ea11ee90370d56cce2f5548a5610c2d6R130-R133)
* Implemented `GetBatchLastMessages` in `MautrixAdapter` to fetch the latest message for each room concurrently using goroutines, improving performance for bulk requests.
* Implemented `GetBatchUnreadCounts` in `MautrixAdapter` to retrieve unread message counts for multiple rooms via a single Matrix sync API call, minimizing HTTP requests and server load.

**Queue handler improvements:**

* Refactored `HandleBatchGetUnreadCounts` in `ReadReceiptHandler` to resolve room aliases up front and use the new batch unread counts method, mapping results and errors back to the original room IDs. [[1]](diffhunk://#diff-a5ba9773e5f2ae7b7de285cfce9aeb0a05547404a67cfea5ad7b6868add3728cL151-R154) [[2]](diffhunk://#diff-a5ba9773e5f2ae7b7de285cfce9aeb0a05547404a67cfea5ad7b6868add3728cL160-R179)
* Refactored `HandleBatchGetLastMessages` in `RoomHandler` to resolve room aliases and use the new batch last message method, mapping results and errors back to the original room IDs. [[1]](diffhunk://#diff-a10dbf91123dbfa97b605b2639784970252069f9d727415fac72d246e5d2583aL777-R780) [[2]](diffhunk://#diff-a10dbf91123dbfa97b605b2639784970252069f9d727415fac72d246e5d2583aL786-R799) [[3]](diffhunk://#diff-a10dbf91123dbfa97b605b2639784970252069f9d727415fac72d246e5d2583aR811-R814)

**Documentation and code clarity:**

* Added and updated comments in handler methods and interface definitions to clarify the efficiency and usage of the new batch operations. [[1]](diffhunk://#diff-a5ba9773e5f2ae7b7de285cfce9aeb0a05547404a67cfea5ad7b6868add3728cR137) [[2]](diffhunk://#diff-a10dbf91123dbfa97b605b2639784970252069f9d727415fac72d246e5d2583aR767)…sages

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch operations to fetch last messages and unread counts for many rooms at once, reducing latency and network calls while preserving per-room results and errors.
  * Handlers now use these batch operations to return consolidated responses with messages, unread counts, and per-room error reporting.

* **Refactor**
  * Internal request flow updated to resolve IDs up front and translate batch results back to original room identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->