### PR TITLE
feat: optimize room join process by marking rooms as read for all joi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ go.work
 bin/
 
 synapse-modules/__pycache__/
+/cmd/fix-canonical-aliases/
+/fix-canonical-aliases
+.claude/settings.local.json

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -300,7 +300,66 @@ func (m *MautrixAdapter) InviteUser(
 		return fmt.Errorf("failed to join room after invite: %w", err)
 	}
 
+	// Mark room as read to clear invite notification from unread count
+	// Get latest event once, then send receipt for this user
+	if latestEventID, err := m.getLatestEventID(ctx, roomID); err != nil {
+		m.logger.Warn("Failed to get latest event for read receipt",
+			"room_id", roomID,
+			"error", err,
+		)
+	} else {
+		m.markRoomAsReadForUsers(ctx, roomID, []id.UserID{inviteeUserID}, latestEventID)
+	}
+
 	return nil
+}
+
+// getLatestEventID retrieves the latest event ID in a room.
+// Used to mark rooms as read after joining.
+func (m *MautrixAdapter) getLatestEventID(
+	ctx context.Context, roomID id.RoomID,
+) (id.EventID, error) {
+	// Use bot intent to get latest event (any user can read room state)
+	intent := m.as.BotIntent()
+	resp, err := intent.Messages(ctx, roomID, "", "", mautrix.DirectionBackward, nil, 1)
+	if err != nil {
+		return "", fmt.Errorf("failed to get latest event: %w", err)
+	}
+
+	if len(resp.Chunk) == 0 {
+		return "", nil // No events in room yet
+	}
+
+	return resp.Chunk[0].ID, nil
+}
+
+// markRoomAsReadForUsers sends read receipts for multiple users using a single event ID.
+// This is optimized for room creation where we need to clear invite notifications for all members.
+func (m *MautrixAdapter) markRoomAsReadForUsers(
+	ctx context.Context, roomID id.RoomID, userIDs []id.UserID, eventID id.EventID,
+) {
+	if eventID == "" {
+		return // No event to mark as read
+	}
+
+	for _, userID := range userIDs {
+		intent := m.as.Intent(userID)
+		if err := intent.SendReceipt(ctx, roomID, eventID, event.ReceiptTypeRead, nil); err != nil {
+			m.logger.Warn("Failed to mark room as read for user",
+				"room_id", roomID,
+				"user_id", userID,
+				"event_id", eventID,
+				"error", err,
+			)
+			// Continue with other users
+		}
+	}
+
+	m.logger.Debug("Marked room as read for users after join",
+		"room_id", roomID,
+		"event_id", eventID,
+		"user_count", len(userIDs),
+	)
 }
 
 // SendMessage sends a message to a room.
@@ -1169,7 +1228,7 @@ func (m *MautrixAdapter) CreateRoomWithAlias(
 	}
 
 	// Auto-join initial members (they were only invited, need to accept)
-	successfulJoins := 0
+	joinedUsers := make([]id.UserID, 0, len(invites))
 	for _, memberUserID := range invites {
 		memberIntent := m.as.Intent(memberUserID)
 		if err := memberIntent.EnsureJoined(ctx, resp.RoomID); err != nil {
@@ -1180,7 +1239,20 @@ func (m *MautrixAdapter) CreateRoomWithAlias(
 			)
 			// Continue with other members, don't fail the whole operation
 		} else {
-			successfulJoins++
+			joinedUsers = append(joinedUsers, memberUserID)
+		}
+	}
+
+	// Mark room as read for all joined users to clear invite notifications
+	// Optimized: get latest event once, send receipts for all users
+	if len(joinedUsers) > 0 {
+		if latestEventID, err := m.getLatestEventID(ctx, resp.RoomID); err != nil {
+			m.logger.Warn("Failed to get latest event for read receipts",
+				"room_id", resp.RoomID,
+				"error", err,
+			)
+		} else {
+			m.markRoomAsReadForUsers(ctx, resp.RoomID, joinedUsers, latestEventID)
 		}
 	}
 
@@ -1189,7 +1261,7 @@ func (m *MautrixAdapter) CreateRoomWithAlias(
 		"room_id", resp.RoomID,
 		"alias", m.idMapper.RoomAlias(alkemioRoomID),
 		"alkemio_room_id", alkemioRoomID,
-		"members_joined", successfulJoins,
+		"members_joined", len(joinedUsers),
 	)
 
 	return resp.RoomID, nil
@@ -1397,7 +1469,7 @@ func (m *MautrixAdapter) CreateSpace(
 	}
 
 	// Auto-join initial members (they were only invited, need to accept)
-	successfulJoins := 0
+	joinedUsers := make([]id.UserID, 0, len(invites))
 	for _, memberUserID := range invites {
 		memberIntent := m.as.Intent(memberUserID)
 		if err := memberIntent.EnsureJoined(ctx, resp.RoomID); err != nil {
@@ -1408,7 +1480,20 @@ func (m *MautrixAdapter) CreateSpace(
 			)
 			// Continue with other members, don't fail the whole operation
 		} else {
-			successfulJoins++
+			joinedUsers = append(joinedUsers, memberUserID)
+		}
+	}
+
+	// Mark space as read for all joined users to clear invite notifications
+	// Optimized: get latest event once, send receipts for all users
+	if len(joinedUsers) > 0 {
+		if latestEventID, err := m.getLatestEventID(ctx, resp.RoomID); err != nil {
+			m.logger.Warn("Failed to get latest event for read receipts",
+				"room_id", resp.RoomID,
+				"error", err,
+			)
+		} else {
+			m.markRoomAsReadForUsers(ctx, resp.RoomID, joinedUsers, latestEventID)
 		}
 	}
 
@@ -1417,7 +1502,7 @@ func (m *MautrixAdapter) CreateSpace(
 		"room_id", resp.RoomID,
 		"alias", m.idMapper.SpaceAlias(alkemioContextID),
 		"alkemio_context_id", alkemioContextID,
-		"members_joined", successfulJoins,
+		"members_joined", len(joinedUsers),
 	)
 
 	return resp.RoomID, nil
@@ -1609,6 +1694,16 @@ func (m *MautrixAdapter) InviteToSpace(ctx context.Context, spaceID id.RoomID, i
 	inviteeIntent := m.as.Intent(inviteeUserID)
 	if err := inviteeIntent.EnsureJoined(ctx, spaceID); err != nil {
 		return fmt.Errorf("failed to join space after invite: %w", err)
+	}
+
+	// Mark space as read to clear invite notification from unread count
+	if latestEventID, err := m.getLatestEventID(ctx, spaceID); err != nil {
+		m.logger.Warn("Failed to get latest event for read receipt",
+			"room_id", spaceID,
+			"error", err,
+		)
+	} else {
+		m.markRoomAsReadForUsers(ctx, spaceID, []id.UserID{inviteeUserID}, latestEventID)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request improves how invite notifications are handled in Matrix rooms and spaces by automatically marking them as read for users after they join. This helps clear unread counts and provides a better user experience. The main changes include new helper methods for marking rooms as read, and updates to the room and space creation flows to use these helpers.

**Improvements to invite notification handling:**

* Added `getLatestEventID` and `markRoomAsReadForUsers` helper methods to `MautrixAdapter` to efficiently mark rooms/spaces as read for one or more users after joining or being invited.
* Updated the `InviteUser` and `InviteToSpace` methods to mark rooms/spaces as read for the invited user after a successful join, clearing invite notifications from their unread count. [[1]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbR303-R364) [[2]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbR1699-R1708)

**Enhancements to room and space creation:**

* Modified `CreateRoomWithAlias` and `CreateSpace` to collect successfully joined users and mark the room/space as read for all of them in a single operation, optimizing the process and clearing notifications for all members. [[1]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbL1172-R1231) [[2]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbL1183-R1255) [[3]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbL1400-R1472) [[4]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbL1411-R1496)
* Updated logging in `CreateRoomWithAlias` and `CreateSpace` to reflect the actual number of users who joined, using the new `joinedUsers` list instead of a simple counter. [[1]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbL1192-R1264) [[2]](diffhunk://#diff-f3bb45901ee247dbc26a63a1615aaeabdf0e15de80263c81d5a576e5ea50a1fbL1420-R1505)…ned users

### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/alkem-io/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/alkem-io/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/alkem-io/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing read receipts for users after joining rooms and spaces. Users are now automatically marked as having read the latest events following invitations and auto-joins, with improved logging and error resilience.
* **Chores**
  * Updated .gitignore with additional ignore rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->