### PR TITLE
ci: Add GHCR container build on PRs

### DIFF
--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -1,0 +1,50 @@
+name: Build & Push Container (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=pr
+            type=sha,prefix=pr-${{ github.event.number }}-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -22,6 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -43,7 +44,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that builds and pushes Docker images to GitHub Container Registry (`ghcr.io`) on pull requests
- Tags images with `pr-<number>` and `pr-<number>-<sha>` for easy identification
- Uses GitHub Actions build cache (`type=gha`) for faster subsequent builds
- Builds for both `linux/amd64` and `linux/arm64` platforms

## Motivation

Currently containers are only published to DockerHub on releases. This workflow enables testing PR container images directly from `ghcr.io` without waiting for a release.

## Test plan

- [ ] Open a PR and verify the workflow runs
- [ ] Verify image appears at `ghcr.io/alkem-io/matrix-adapter-go:pr-<number>`
- [ ] Verify image is pullable and runnable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow to build and publish multi-architecture container images for pull requests, improving automated image verification and consistency for proposed changes. Continuous builds include cache usage and reproducible tagging to make PR image artifacts easier to trace and validate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->