### PR TITLE
ci: fix deploy workflows — revert build runner to ubuntu-latest

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -6,19 +6,8 @@ on:
 
 jobs:
   build:
-    runs-on: m4
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker
-        run: |
-          if ! command -v brew &>/dev/null; then
-            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            eval "$(/opt/homebrew/bin/brew shellenv)"
-            echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          fi
-          brew install docker colima
-          colima delete --force 2>/dev/null || true
-          colima start
-
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -5,19 +5,8 @@ on:
 
 jobs:
   build:
-    runs-on: m4
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker
-        run: |
-          if ! command -v brew &>/dev/null; then
-            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            eval "$(/opt/homebrew/bin/brew shellenv)"
-            echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          fi
-          brew install docker colima
-          colima delete --force 2>/dev/null || true
-          colima start
-
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -5,19 +5,8 @@ on:
 
 jobs:
   build:
-    runs-on: m4
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker
-        run: |
-          if ! command -v brew &>/dev/null; then
-            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            eval "$(/opt/homebrew/bin/brew shellenv)"
-            echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          fi
-          brew install docker colima
-          colima delete --force 2>/dev/null || true
-          colima start
-
       - name: Checkout repository
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- Reverts the dev/test/sandbox deploy workflows from the `m4` (ARM64) runner back to `ubuntu-latest` (AMD64)
- Removes the Colima Docker setup step (not needed on GitHub-hosted runners)
- Bumps `docker/login-action` from v3 to v4

## Problem

PR #33 moved all build jobs to the `m4` self-hosted ARM64 runner. This works for the public-registry workflows (`container-build`, `docker-hub`, `ghcr-pr`) because they use `docker/build-push-action` with `platforms: linux/amd64,linux/arm64` — buildx cross-compiles regardless of host architecture.

However, the deploy workflows use plain `docker build`, which builds for the **host architecture only**. On the ARM64 runner this produces ARM64 images. The Hetzner k8s nodes are **AMD64**, so kubelet fails to find a matching image manifest during pull.

## Fix

Revert the three deploy workflows to `ubuntu-latest`. Plain `docker build` on an AMD64 runner natively produces AMD64 images — which is all these workflows need. The private registry is a temporary staging area for deploying to AMD-only nodes; multi-arch support adds no value here.

| Workflow | Runner | Reason |
|----------|--------|--------|
| `build-deploy-k8s-dev-hetzner` | `ubuntu-latest` | Deploys to AMD64 k8s nodes |
| `build-deploy-k8s-test-hetzner` | `ubuntu-latest` | Deploys to AMD64 k8s nodes |
| `build-deploy-k8s-sandbox-hetzner` | `ubuntu-latest` | Deploys to AMD64 k8s nodes |
| `container-build` | `m4` + buildx | Multi-arch for distribution *(unchanged)* |
| `build-release-docker-hub` | `m4` + buildx | Multi-arch release *(unchanged)* |
| `build-push-ghcr-pr` | `m4` + buildx | Multi-arch PR preview *(unchanged)* |

## Test plan

- [ ] Trigger test deploy workflow and verify the image is pulled successfully by k8s
- [ ] Verify dev deploy triggers on push to develop and completes successfully


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configuration across deployment workflows to use `ubuntu-latest` runner
  * Streamlined Docker setup process in CI/CD pipelines by removing manual environment installation steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->