### PR TITLE
ci: revert m4 runner to ubuntu-latest with QEMU

### DIFF
--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -6,25 +6,17 @@ on:
 
 jobs:
   build:
-    runs-on: m4
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Set up Docker
-        run: |
-          if ! command -v brew &>/dev/null; then
-            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            eval "$(/opt/homebrew/bin/brew shellenv)"
-            echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          fi
-          brew install docker colima
-          colima delete --force 2>/dev/null || true
-          colima start
-
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -6,19 +6,8 @@ on:
 
 jobs:
   docker:
-    runs-on: m4
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker
-        run: |
-          if ! command -v brew &>/dev/null; then
-            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            eval "$(/opt/homebrew/bin/brew shellenv)"
-            echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          fi
-          brew install docker colima
-          colima delete --force 2>/dev/null || true
-          colima start
-
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -52,6 +41,9 @@ jobs:
             echo "tags=${TAGS}"
             echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -5,19 +5,8 @@ on:
 
 jobs:
   build:
-    runs-on: m4
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker
-        run: |
-          if ! command -v brew &>/dev/null; then
-            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            eval "$(/opt/homebrew/bin/brew shellenv)"
-            echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          fi
-          brew install docker colima
-          colima delete --force 2>/dev/null || true
-          colima start
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -29,6 +18,9 @@ jobs:
           tags: |
             type=sha
             type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Summary
- Replace custom `m4` ARM runner + Colima Docker setup with standard `ubuntu-latest` runner
- Add `docker/setup-qemu-action` for multiarch (`linux/amd64,linux/arm64`) emulation
- Applied to all three container workflows: `build-push-ghcr-pr.yml`, `build-release-docker-hub.yml`, `container-build.yml`

## Test plan
- [ ] Verify PR container build triggers and completes on `ubuntu-latest`
- [ ] Confirm multiarch images are produced (amd64 + arm64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline by migrating build infrastructure to Linux-based runners for improved reliability and efficiency
  * Enabled simultaneous multi-architecture Docker container builds to support a broader range of processor architectures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->