### PR TITLE
fix: remove bulk invites from room/space creation

### DIFF
--- a/cmd/gen-events/main.go
+++ b/cmd/gen-events/main.go
@@ -24,7 +24,7 @@ func main() {
 	outputDir := os.Args[1]
 
 	// Ensure output directory exists
-	if err := os.MkdirAll(outputDir, 0750); err != nil {
+	if err := os.MkdirAll(filepath.Clean(outputDir), 0750); err != nil { //nolint:gosec // outputDir is a CLI argument, not user-tainted input
 		fmt.Printf("Error creating output directory: %v\n", err)
 		os.Exit(1)
 	}
@@ -55,7 +55,7 @@ func main() {
 	eventContent := generateTSContent(allEvents)
 
 	// 4. Write event type file
-	err = os.WriteFile(eventTypeFile, []byte(eventContent), 0600)
+	err = os.WriteFile(filepath.Clean(eventTypeFile), []byte(eventContent), 0600) //nolint:gosec // build-time codegen tool
 	if err != nil {
 		fmt.Printf("Error writing event type file: %v\n", err)
 		os.Exit(1)
@@ -72,7 +72,7 @@ func main() {
 	// 7. Generate commands.ts
 	commandsFile := filepath.Join(outputDir, "commands.ts")
 	commandsContent := generateCommandsTS(commands)
-	err = os.WriteFile(commandsFile, []byte(commandsContent), 0600)
+	err = os.WriteFile(filepath.Clean(commandsFile), []byte(commandsContent), 0600) //nolint:gosec // build-time codegen tool
 	if err != nil {
 		fmt.Printf("Error writing commands file: %v\n", err)
 		os.Exit(1)
@@ -278,7 +278,7 @@ func generateCommandsTS(commands []CommandDef) string {
 	sort.Strings(typeList)
 
 	for _, t := range typeList {
-		sb.WriteString(fmt.Sprintf("  %s,\n", t))
+		fmt.Fprintf(&sb, "  %s,\n", t)
 	}
 	sb.WriteString("} from './dto';\n\n")
 
@@ -308,9 +308,9 @@ func generateCommandsTS(commands []CommandDef) string {
 	)
 
 	for _, cmd := range cmdList {
-		sb.WriteString(fmt.Sprintf("  '%s': {\n", cmd.Topic))
-		sb.WriteString(fmt.Sprintf("    request: {} as %s,\n", cmd.RequestType))
-		sb.WriteString(fmt.Sprintf("    response: {} as %s,\n", cmd.ResponseType))
+		fmt.Fprintf(&sb, "  '%s': {\n", cmd.Topic)
+		fmt.Fprintf(&sb, "    request: {} as %s,\n", cmd.RequestType)
+		fmt.Fprintf(&sb, "    response: {} as %s,\n", cmd.ResponseType)
 		sb.WriteString("  },\n")
 	}
 
@@ -330,8 +330,8 @@ func generateCommandsTS(commands []CommandDef) string {
 		)
 
 		for _, evt := range eventList {
-			sb.WriteString(fmt.Sprintf("  '%s': {\n", evt.Topic))
-			sb.WriteString(fmt.Sprintf("    payload: {} as %s,\n", evt.ResponseType))
+			fmt.Fprintf(&sb, "  '%s': {\n", evt.Topic)
+			fmt.Fprintf(&sb, "    payload: {} as %s,\n", evt.ResponseType)
 			sb.WriteString("  },\n")
 		}
 
@@ -475,7 +475,7 @@ func generateTSContent(events map[string]string) string {
 	)
 
 	for _, p := range pairs {
-		sb.WriteString(fmt.Sprintf("  %s = '%s',\n", p.Key, p.Value))
+		fmt.Fprintf(&sb, "  %s = '%s',\n", p.Key, p.Value)
 	}
 
 	sb.WriteString("\n}\n")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,7 @@ func Load() (*Config, error) {
 		configPath = "config.yaml"
 	}
 
-	if _, err := os.Stat(configPath); err == nil {
+	if _, err := os.Stat(configPath); err == nil { //nolint:gosec // config path from env var
 		//nolint:gosec // Config file path is controlled by environment variable
 		f, err := os.Open(configPath)
 		if err != nil {

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -1963,41 +1963,14 @@ func (m *MautrixAdapter) CreateSpace(
 		return "", fmt.Errorf("failed to create space: %w", err)
 	}
 
-	// Auto-join initial members
-	joinedUsers := make([]id.UserID, 0, len(memberUserIDs))
-	for _, memberUserID := range memberUserIDs {
-		memberIntent := m.as.Intent(memberUserID)
-		if err := memberIntent.EnsureJoined(ctx, resp.RoomID); err != nil {
-			m.logger.Warn("Failed to auto-join member to space",
-				"room_id", resp.RoomID,
-				"user_id", memberUserID,
-				"error", err,
-			)
-			// Continue with other members, don't fail the whole operation
-		} else {
-			joinedUsers = append(joinedUsers, memberUserID)
-		}
-	}
-
-	// Mark space as read for all joined users to clear invite notifications
-	// Optimized: get latest event once, send receipts for all users
-	if len(joinedUsers) > 0 {
-		if latestEventID, err := m.getLatestEventID(ctx, resp.RoomID); err != nil {
-			m.logger.Warn("Failed to get latest event for read receipts",
-				"room_id", resp.RoomID,
-				"error", err,
-			)
-		} else {
-			m.markRoomAsReadForUsers(ctx, resp.RoomID, joinedUsers, latestEventID)
-		}
-	}
+	joinedCount := m.autoJoinAndMarkRead(ctx, resp.RoomID, memberUserIDs)
 
 	m.logger.Info(
 		"Space created",
 		"room_id", resp.RoomID,
 		"alias", m.idMapper.SpaceAlias(alkemioContextID),
 		"alkemio_context_id", alkemioContextID,
-		"members_joined", len(joinedUsers),
+		"members_joined", joinedCount,
 	)
 
 	return resp.RoomID, nil

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -1607,14 +1607,16 @@ func (m *MautrixAdapter) CreateRoomWithAlias(
 	// Use bot intent for creating rooms
 	intent := m.as.BotIntent()
 
-	// Prepare initial invites
-	invites := make([]id.UserID, 0, len(initialMembers))
+	// Ensure all members exist in Matrix (register ghost users).
+	// Members are joined individually after room creation to avoid
+	// Synapse's per-room invite rate limit (default burst_count: 10).
+	memberUserIDs := make([]id.UserID, 0, len(initialMembers))
 	for _, member := range initialMembers {
 		userID, err := m.EnsureUser(ctx, member)
 		if err != nil {
 			return "", fmt.Errorf("failed to ensure member %s: %w", member.ID, err)
 		}
-		invites = append(invites, userID)
+		memberUserIDs = append(memberUserIDs, userID)
 	}
 
 	// Determine preset based on room type
@@ -1636,7 +1638,6 @@ func (m *MautrixAdapter) CreateRoomWithAlias(
 		Topic:    topic,
 		Preset:   preset,
 		IsDirect: isDirect,
-		Invite:   invites,
 	}
 
 	// Add join rule state event if provided (following CreateSpace pattern)
@@ -1684,7 +1685,7 @@ func (m *MautrixAdapter) CreateRoomWithAlias(
 		return "", fmt.Errorf("failed to set alias on room %s (%s): %w", resp.RoomID, fullAlias, err)
 	}
 
-	joinedCount := m.autoJoinAndMarkRead(ctx, resp.RoomID, invites)
+	joinedCount := m.autoJoinAndMarkRead(ctx, resp.RoomID, memberUserIDs)
 
 	// Bot leaves only if other members are present — an empty room becomes
 	// unreachable if the last member leaves (Synapse loses server tracking).
@@ -1894,15 +1895,17 @@ func (m *MautrixAdapter) CreateSpace(
 
 	intent := m.as.BotIntent()
 
-	// Prepare initial invites
-	invites := make([]id.UserID, 0, len(initialMembers))
+	// Ensure all members exist in Matrix (register ghost users).
+	// Members are joined individually after creation to avoid
+	// Synapse's per-room invite rate limit (default burst_count: 10).
+	memberUserIDs := make([]id.UserID, 0, len(initialMembers))
 	for _, member := range initialMembers {
 		userID, err := m.EnsureUser(ctx, member)
 		if err != nil {
-			m.logger.Warn("Failed to ensure member for space invite", "member_id", member.ID, "error", err)
+			m.logger.Warn("Failed to ensure member for space", "member_id", member.ID, "error", err)
 			continue
 		}
-		invites = append(invites, userID)
+		memberUserIDs = append(memberUserIDs, userID)
 	}
 
 	// Map join rule to Matrix preset
@@ -1917,7 +1920,6 @@ func (m *MautrixAdapter) CreateSpace(
 		Topic:         topic,
 		Preset:        preset,
 		RoomAliasName: aliasLocalpart,
-		Invite:        invites,
 		CreationContent: map[string]interface{}{
 			"type": "m.space",
 		},
@@ -1961,9 +1963,9 @@ func (m *MautrixAdapter) CreateSpace(
 		return "", fmt.Errorf("failed to create space: %w", err)
 	}
 
-	// Auto-join initial members (they were only invited, need to accept)
-	joinedUsers := make([]id.UserID, 0, len(invites))
-	for _, memberUserID := range invites {
+	// Auto-join initial members
+	joinedUsers := make([]id.UserID, 0, len(memberUserIDs))
+	for _, memberUserID := range memberUserIDs {
 		memberIntent := m.as.Intent(memberUserID)
 		if err := memberIntent.EnsureJoined(ctx, resp.RoomID); err != nil {
 			m.logger.Warn("Failed to auto-join member to space",


### PR DESCRIPTION
## Summary

- Remove `Invite` list from `createRoom` requests in both `CreateRoomWithAlias` and `CreateSpace`
- Members are already joined individually after creation via `EnsureJoined` (appservice privilege), making the invite list redundant
- Fixes `M_UNKNOWN (HTTP 400): Cannot invite so many users at once` when creating rooms with >10 members

## Root cause

Synapse's `rc_invites.per_room` rate limit (default `burst_count: 10`) rejects room creation requests that include more than 10 invitees. The appservice should be exempt, but the exemption doesn't cover the `createRoom` invite path in our Synapse version (v1.132.0).

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes
- [ ] Create a room with >10 members — should succeed
- [ ] Verify all members are joined after creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Normalized file path handling across operations for more consistent cross-platform behavior
  * Simplified internal string formatting to improve efficiency and maintainability

* **Refactor**
  * Improved room and space creation flows and member management, enhancing reliability of invitations, auto-join behavior, and related logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->