### PR TITLE
fix(ci): remove npm@11 upgrade breaking publish workflow

### DIFF
--- a/.github/workflows/publish-lib.yml
+++ b/.github/workflows/publish-lib.yml
@@ -38,9 +38,6 @@ jobs:
         with:
           version: 10
 
-      - name: Update npm
-        run: npm install -g npm@11
-
       - name: Generate Library
         run: make generate
 


### PR DESCRIPTION
## Summary

- Remove `npm install -g npm@11` step from publish-lib workflow
- Node 22.22.2's bundled npm has a corrupted dependency tree (missing `promise-retry`), causing the upgrade to fail
- The upgrade was unnecessary — we use pnpm for builds/publishing, and the only npm usage (`npm version`) works with the bundled version

## Test plan

- [ ] Publish workflow passes on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow by removing a redundant npm upgrade step during the publish process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->