### PR TITLE
fix(ci): use Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-lib.yml
+++ b/.github/workflows/publish-lib.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: ${{ startsWith(github.ref, 'refs/tags/v') && 'https://registry.npmjs.org' || '' }}
 
       - name: Install pnpm


### PR DESCRIPTION
## Summary

- Switch from Node 22 to Node 24 in publish-lib workflow
- Node 22 ships npm v10 which doesn't support the OIDC token exchange required by npm trusted publishing (needs npm >= 11.5.1)
- Node 24 ships npm 11.x natively, fixing the `E404` on `pnpm publish --provenance`

## Context

After PR #40 removed the broken `npm install -g npm@11` step, the publish still fails because npm v10 (bundled with Node 22) can't do the OIDC handshake. The provenance signing succeeds but the PUT returns 404.

## Test plan

- [ ] Merge, delete `v0.8.8` tag/release, re-create release to trigger publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build pipeline to use a newer Node.js runtime version, ensuring compatibility with the latest tooling and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->