### PR TITLE
fix: bot admin promotion fails on fresh Synapse DB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          args: --timeout=5m
+
+      - name: Vet
+        run: go vet ./...

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -241,7 +241,9 @@ func (m *MautrixAdapter) ensureBotAdmin(ctx context.Context) {
 	// M_EXCLUSIVE check blocks external admin API calls until the appservice
 	// itself has registered the user via POST /register.
 	if err := m.as.BotIntent().EnsureRegistered(ctx); err != nil {
-		m.logger.Debug("Bot appservice registration", "result", err)
+		m.logger.Debug("Bot appservice registration check", "error", err)
+	} else {
+		m.logger.Debug("Bot appservice registration ensured")
 	}
 
 	m.logger.Info("Bot user already exists, promoting via temp admin...")

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -158,19 +158,18 @@ func safePrefix(s string, n int) string {
 
 // Connect initializes the connection to the Matrix homeserver.
 func (m *MautrixAdapter) Connect(ctx context.Context) error {
-	// Step 1: Ensure bot user exists and is a server admin BEFORE appservice starts.
-	// This uses direct HTTP calls to Synapse, independent of the appservice framework.
+	// Step 1: Try to ensure bot is admin (quick path — works on restarts).
 	m.ensureBotAdmin(ctx)
 
 	// Step 2: Start the AppService
 	m.logger.Info("Initializing Matrix AppService connection")
 
-	startedCh := make(chan error, 1)
 	go func() {
 		m.as.Start()
 		m.logger.Warn("AppService HTTP server stopped")
 	}()
 
+	startedCh := make(chan error, 1)
 	if err := m.waitForServerReady(ctx, startedCh); err != nil {
 		return fmt.Errorf("appservice failed to start: %w", err)
 	}
@@ -237,11 +236,19 @@ func (m *MautrixAdapter) ensureBotAdmin(ctx context.Context) {
 		m.logger.Info("Bot registered as server admin via shared secret")
 		return
 	}
+	// Ensure the bot is registered as an appservice user before promoting.
+	// On a fresh DB, Synapse creates the bot from registration YAML but the
+	// M_EXCLUSIVE check blocks external admin API calls until the appservice
+	// itself has registered the user via POST /register.
+	if err := m.as.BotIntent().EnsureRegistered(ctx); err != nil {
+		m.logger.Debug("Bot appservice registration", "result", err)
+	}
+
 	m.logger.Info("Bot user already exists, promoting via temp admin...")
 
-	// Bot exists but isn't admin — bootstrap via temp admin user
+	// Bot exists but isn't admin — try temp admin approach
 	if err := m.promoteViaTemporaryAdmin(ctx, secret); err != nil {
-		m.logger.Warn("Failed to bootstrap bot admin",
+		m.logger.Warn("Failed to promote bot via temp admin",
 			"error", err, "bot_mxid", m.as.BotMXID())
 	} else {
 		m.logger.Info("Bot promoted to server admin", "bot_mxid", m.as.BotMXID())

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -169,8 +169,7 @@ func (m *MautrixAdapter) Connect(ctx context.Context) error {
 		m.logger.Warn("AppService HTTP server stopped")
 	}()
 
-	startedCh := make(chan error, 1)
-	if err := m.waitForServerReady(ctx, startedCh); err != nil {
+	if err := m.waitForServerReady(ctx); err != nil {
 		return fmt.Errorf("appservice failed to start: %w", err)
 	}
 
@@ -500,7 +499,7 @@ func (m *MautrixAdapter) registerSharedSecretUser(
 }
 
 // waitForServerReady probes the AppService HTTP server until it's ready or times out.
-func (m *MautrixAdapter) waitForServerReady(ctx context.Context, _ chan error) error {
+func (m *MautrixAdapter) waitForServerReady(ctx context.Context) error {
 	const (
 		timeout      = 5 * time.Second
 		pollInterval = 25 * time.Millisecond


### PR DESCRIPTION
## Summary

- Call `BotIntent().EnsureRegistered()` before attempting temp admin promotion
- On a fresh DB, the bot user exists (from Synapse's registration YAML) but isn't registered as an appservice user yet
- This causes `PUT /v2/users/{bot}` to fail with `M_EXCLUSIVE` because Synapse doesn't recognize the appservice's claim on the user
- After `EnsureRegistered` (`POST /register` with `m.login.application_service`), the M_EXCLUSIVE check passes

## Root cause

Synapse creates the bot user from the appservice registration YAML on startup, but the `M_EXCLUSIVE` check for the admin API requires the user to have been properly registered by the appservice itself. Until `POST /register` is called with the appservice auth type, external admin users cannot modify the bot via the admin API.

## Test plan

- [x] Fresh DB: bot promoted to admin on first run
- [x] Restart: bot promoted to admin immediately (no regression)
- [ ] `make build` passes
- [ ] `make test` passes
- [ ] `make lint` passes (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot administrator setup and promotion flow with more robust registration and readiness checks for more reliable admin assignment.

* **Chores**
  * Clarified logging messages related to bot promotion.
  * Added a CI workflow to run build, tests, vetting, and linting automatically on PRs and key branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->