### PR TITLE
fix: canonical alias migration fails with insufficient power level

### DIFF
--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -276,7 +276,8 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 	botMXID := m.as.BotMXID()
 
 	for _, room := range rooms {
-		if room.RoomType == "m.space" || room.CanonicalAlias == "" {
+		if room.RoomType == "m.space" || room.CanonicalAlias == "" ||
+			m.idMapper.AlkemioRoomID(room.CanonicalAlias) == uuid.Nil {
 			continue
 		}
 

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -182,11 +182,8 @@ func (m *MautrixAdapter) Connect(ctx context.Context) error {
 		m.logger.Info("Matrix AppService connected", "user_id", whoami.UserID)
 	}
 
-	// Step 4: Migration cleanup for existing deployments
-	m.redactCanonicalAliasesFromRooms(ctx)
-	m.leaveBotFromNonSpaceRooms(ctx)
-
-	// Step 5: Set bot display name
+	// Step 4: Set bot display name (before any room operations, so creation
+	// events show the display name instead of the raw UUID).
 	if m.botDisplayName != "" {
 		botIntent := m.as.BotIntent()
 		if err := botIntent.SetDisplayName(ctx, m.botDisplayName); err != nil {
@@ -195,6 +192,10 @@ func (m *MautrixAdapter) Connect(ctx context.Context) error {
 			m.logger.Info("Bot display name set", "display_name", m.botDisplayName)
 		}
 	}
+
+	// Step 5: Migration cleanup for existing deployments
+	m.redactCanonicalAliasesFromRooms(ctx)
+	m.leaveBotFromNonSpaceRooms(ctx)
 
 	return nil
 }
@@ -271,23 +272,31 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 	}
 
 	redactedCount := 0
+	botIntent := m.as.BotIntent()
+	botMXID := m.as.BotMXID()
+
 	for _, room := range rooms {
 		if room.RoomType == "m.space" || room.CanonicalAlias == "" {
 			continue
 		}
 
-		memberIntent := m.findGhostIntentInRoom(ctx, room.RoomID)
-		if memberIntent == nil {
-			m.logger.Warn("No ghost user found in room for alias cleanup",
-				"room_id", room.RoomID)
+		// Join bot via admin API (bypasses join rules), clear alias, then leave.
+		if err := m.admin.JoinRoom(ctx, room.RoomID, botMXID); err != nil {
+			m.logger.Warn("Failed to join room for alias cleanup",
+				"room_id", room.RoomID, "error", err)
 			continue
 		}
 
-		if _, err := memberIntent.SendStateEvent(ctx, room.RoomID, event.StateCanonicalAlias, "", map[string]interface{}{}); err != nil {
+		if _, err := botIntent.SendStateEvent(ctx, room.RoomID, event.StateCanonicalAlias, "", map[string]interface{}{}); err != nil {
 			m.logger.Warn("Failed to clear canonical alias",
 				"room_id", room.RoomID, "error", err)
 		} else {
 			redactedCount++
+		}
+
+		if _, err := botIntent.LeaveRoom(ctx, room.RoomID); err != nil {
+			m.logger.Warn("Failed to leave room after alias cleanup",
+				"room_id", room.RoomID, "error", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fix `redactCanonicalAliasesFromRooms` migration that fails on every restart with `user_level (0) < send_level (50)`
- Ghost users have default PL 0, but state events require PL 50
- Now joins the bot via admin API (bot has PL 100 as room creator), clears the alias, then leaves
- Migration is idempotent — rooms with empty canonical alias are skipped on subsequent restarts

## Test plan

- [x] `make build` passes
- [x] `make lint` — 0 issues
- [ ] Deploy: verify warnings stop after first successful migration run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bot display name is now applied earlier during startup to ensure subsequent room operations use the updated name.
  * Canonical-alias cleanup is more reliable: it skips unmapped rooms, actively joins rooms to clear stale aliases, and leaves afterwards.
  * Improved logging and counting for alias cleanup successes and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->