### PR TITLE
fix: admin-join bot when ghost PL insufficient for state events

### DIFF
--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -307,11 +307,11 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 }
 
 // findGhostIntentInRoom finds the ghost user with the highest power level in a room.
-// Returns their intent, or nil if no ghost users are found.
-func (m *MautrixAdapter) findGhostIntentInRoom(ctx context.Context, roomID id.RoomID) intentAPI {
+// Returns their intent and PL, or nil if no ghost users are found.
+func (m *MautrixAdapter) findGhostIntentInRoom(ctx context.Context, roomID id.RoomID) (intentAPI, float64) {
 	members, err := m.admin.GetRoomMembers(ctx, roomID)
 	if err != nil {
-		return nil
+		return nil, -1
 	}
 
 	// Get power levels to find the most privileged ghost
@@ -352,7 +352,7 @@ func (m *MautrixAdapter) findGhostIntentInRoom(ctx context.Context, roomID id.Ro
 		}
 	}
 
-	return bestIntent
+	return bestIntent, bestPL
 }
 
 // leaveBotFromNonSpaceRooms removes the bot from all rooms that are not spaces.
@@ -1176,16 +1176,22 @@ func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID)
 		}
 	}
 
-	// Bot not in room — find a ghost user
-	intent := m.findGhostIntentInRoom(ctx, roomID)
-	if intent != nil {
-		m.logger.Debug("getIntentForRoom: using ghost user", "room_id", roomID)
+	// Bot not in room — find a ghost user with sufficient PL for state events (>= 50)
+	intent, pl := m.findGhostIntentInRoom(ctx, roomID)
+	if intent != nil && pl >= 50 {
+		m.logger.Debug("getIntentForRoom: using ghost user", "room_id", roomID, "power_level", pl)
 		return intent
 	}
 
-	// Last resort — admin-join the bot so it can perform the write.
+	// No ghost with sufficient PL — admin-join the bot (PL 100 as room creator).
 	// The bot will leave once a real member is added (via leaveBotIfNotNeeded).
-	m.logger.Debug("getIntentForRoom: no ghost user found, admin-joining bot", "room_id", roomID)
+	if intent != nil {
+		m.logger.Debug("getIntentForRoom: ghost PL too low, admin-joining bot",
+			"room_id", roomID, "ghost_pl", pl)
+	} else {
+		m.logger.Debug("getIntentForRoom: no ghost user found, admin-joining bot",
+			"room_id", roomID)
+	}
 	if err := m.admin.JoinRoom(ctx, roomID, m.as.BotMXID()); err != nil {
 		m.logger.Debug("getIntentForRoom: admin join failed",
 			"room_id", roomID, "error", err)

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -1158,10 +1158,15 @@ func (m *MautrixAdapter) SetCustomState(ctx context.Context, roomID id.RoomID, s
 	return nil
 }
 
-// getIntentForRoom returns an intent that has access to a room.
-// Tries BotIntent first (for spaces where bot is a member), then falls back
-// to finding a joined ghost user via the admin API.
-func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID) intentAPI {
+// getIntentForRoom returns an intent that has access to a room with at least
+// the given power level. Tries BotIntent first (for spaces where bot is a member),
+// then falls back to finding a joined ghost user with sufficient PL.
+// If no suitable intent is found, admin-joins the bot (PL 100 as room creator).
+func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID, minPL ...float64) intentAPI {
+	requiredPL := float64(50) // default: state events require PL 50
+	if len(minPL) > 0 {
+		requiredPL = minPL[0]
+	}
 	botIntent := m.as.BotIntent()
 
 	// Check if bot is in the room via admin API
@@ -1176,9 +1181,9 @@ func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID)
 		}
 	}
 
-	// Bot not in room — find a ghost user with sufficient PL for state events (>= 50)
+	// Bot not in room — find a ghost user with sufficient PL
 	intent, pl := m.findGhostIntentInRoom(ctx, roomID)
-	if intent != nil && pl >= 50 {
+	if intent != nil && pl >= requiredPL {
 		m.logger.Debug("getIntentForRoom: using ghost user", "room_id", roomID, "power_level", pl)
 		return intent
 	}

--- a/internal/infrastructure/matrix/mautrix_intent_test.go
+++ b/internal/infrastructure/matrix/mautrix_intent_test.go
@@ -1989,8 +1989,9 @@ func TestFindGhostIntentInRoom_FindsHighestPL(t *testing.T) {
 	})
 	a := newFullTestAdapter(as, admin)
 
-	intent := a.findGhostIntentInRoom(context.Background(), "!room:test.local")
+	intent, pl := a.findGhostIntentInRoom(context.Background(), "!room:test.local")
 	assert.Equal(t, ghost2Intent, intent, "should return ghost with highest power level")
+	assert.Equal(t, float64(100), pl)
 }
 
 func TestFindGhostIntentInRoom_NoGhosts(t *testing.T) {
@@ -2003,8 +2004,9 @@ func TestFindGhostIntentInRoom_NoGhosts(t *testing.T) {
 	as := newMockAS(&mockIntentAPI{}, nil)
 	a := newFullTestAdapter(as, admin)
 
-	intent := a.findGhostIntentInRoom(context.Background(), "!room:test.local")
+	intent, pl := a.findGhostIntentInRoom(context.Background(), "!room:test.local")
 	assert.Nil(t, intent, "should return nil when no ghost users")
+	assert.Equal(t, float64(-1), pl)
 }
 
 func TestFindGhostIntentInRoom_MemberFetchError(t *testing.T) {
@@ -2014,6 +2016,7 @@ func TestFindGhostIntentInRoom_MemberFetchError(t *testing.T) {
 	as := newMockAS(&mockIntentAPI{}, nil)
 	a := newFullTestAdapter(as, admin)
 
-	intent := a.findGhostIntentInRoom(context.Background(), "!room:test.local")
+	intent, pl := a.findGhostIntentInRoom(context.Background(), "!room:test.local")
 	assert.Nil(t, intent)
+	assert.Equal(t, float64(-1), pl)
 }

--- a/internal/infrastructure/matrix/mautrix_intent_test.go
+++ b/internal/infrastructure/matrix/mautrix_intent_test.go
@@ -2020,3 +2020,52 @@ func TestFindGhostIntentInRoom_MemberFetchError(t *testing.T) {
 	assert.Nil(t, intent)
 	assert.Equal(t, float64(-1), pl)
 }
+
+func TestGetIntentForRoom_LowPLGhost_AdminJoinFallback(t *testing.T) {
+	botIntent := &mockIntentAPI{}
+	ghostIntent := &mockIntentAPI{}
+	ghostUserID := expectedUserID(testActorID)
+	admin := &mockAdminAPI{
+		getRoomMembersResult: []string{
+			ghostUserID.String(),
+		},
+		getStateEventContentResult: map[string]interface{}{
+			"users": map[string]interface{}{
+				ghostUserID.String(): float64(10),
+			},
+		},
+	}
+	as := newMockAS(botIntent, map[id.UserID]intentAPI{
+		ghostUserID: ghostIntent,
+	})
+	a := newFullTestAdapter(as, admin)
+
+	intent := a.getIntentForRoom(context.Background(), "!room:test.local")
+	assert.Equal(t, botIntent, intent, "should admin-join bot when ghost PL < 50")
+	assert.Len(t, admin.joinRoomCalls, 1)
+}
+
+func TestGetIntentForRoom_CustomMinPL(t *testing.T) {
+	botIntent := &mockIntentAPI{}
+	ghostIntent := &mockIntentAPI{}
+	ghostUserID := expectedUserID(testActorID)
+	admin := &mockAdminAPI{
+		getRoomMembersResult: []string{
+			ghostUserID.String(),
+		},
+		getStateEventContentResult: map[string]interface{}{
+			"users": map[string]interface{}{
+				ghostUserID.String(): float64(10),
+			},
+		},
+	}
+	as := newMockAS(botIntent, map[id.UserID]intentAPI{
+		ghostUserID: ghostIntent,
+	})
+	a := newFullTestAdapter(as, admin)
+
+	// Ghost has PL 10 — sufficient if caller only needs PL 0
+	intent := a.getIntentForRoom(context.Background(), "!room:test.local", 0)
+	assert.Equal(t, ghostIntent, intent, "should use ghost when PL >= minPL")
+	assert.Len(t, admin.joinRoomCalls, 0, "should not admin-join bot")
+}


### PR DESCRIPTION
## Summary

- `getIntentForRoom` now checks if the ghost's power level is >= 50 (required for state events)
- If ghost PL is too low, admin-joins the bot (PL 100 as room creator) instead of returning a ghost that will get 403
- `findGhostIntentInRoom` now returns both the intent and PL for the caller to decide

## Problem

After the bot leaves rooms, only ghost users (PL 0) remain. State events require PL 50. Operations like `SetSpaceParent`, `UpdateRoomState`, and `SetCustomState` fail with:
```
M_FORBIDDEN (HTTP 403): You don't have permission to post that to the room. user_level (0) < send_level (50)
```

## Test plan

- [x] `make build` passes
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [ ] Deploy: verify SetSpaceParent and UpdateRoom work for rooms where bot has left

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ghost/user selection now preserves and evaluates a computed power level; ghost users are used only when meeting a configurable minimum.
  * Improved fallback when the bot isn't in a room: clearer behavior and logging differentiates low-power ghosts from no-ghost cases and still triggers bot join when needed.

* **Tests**
  * Updated tests to validate power-level handling, admin-join fallback, and custom minimum power-level behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->