### PR TITLE
fix: remove admin.JoinRoom to prevent DAG corruption from duplicate joins

### DIFF
--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -273,7 +273,6 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 
 	redactedCount := 0
 	botIntent := m.as.BotIntent()
-	botMXID := m.as.BotMXID()
 
 	for _, room := range rooms {
 		if room.RoomType == "m.space" || room.CanonicalAlias == "" ||
@@ -281,13 +280,11 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 			continue
 		}
 
-		// Join bot via admin API (bypasses join rules), clear alias, then leave.
-		if err := m.admin.JoinRoom(ctx, room.RoomID, botMXID); err != nil {
-			m.logger.Warn("Failed to join room for alias cleanup",
-				"room_id", room.RoomID, "error", err)
-			continue
-		}
-
+		// Clear canonical alias via bot intent. SendStateEvent's built-in
+		// EnsureJoined handles joining the room (single join, no duplication).
+		// Do NOT use admin.JoinRoom here — it bypasses the mautrix StateStore
+		// cache, causing EnsureJoined to create a duplicate join event which
+		// corrupts the room's event DAG.
 		if _, err := botIntent.SendStateEvent(ctx, room.RoomID, event.StateCanonicalAlias, "", map[string]interface{}{}); err != nil {
 			m.logger.Warn("Failed to clear canonical alias",
 				"room_id", room.RoomID, "error", err)
@@ -1188,18 +1185,18 @@ func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID,
 		return intent
 	}
 
-	// No ghost with sufficient PL — admin-join the bot (PL 100 as room creator).
-	// The bot will leave once a real member is added (via leaveBotIfNotNeeded).
+	// No ghost with sufficient PL — return bot intent.
+	// The caller's SendStateEvent will call EnsureJoined automatically,
+	// which handles joining via a single join event (no StateStore desync).
+	// Do NOT use admin.JoinRoom here — it bypasses the mautrix StateStore,
+	// causing EnsureJoined to create a duplicate join event which corrupts
+	// the room's event DAG.
 	if intent != nil {
-		m.logger.Debug("getIntentForRoom: ghost PL too low, admin-joining bot",
+		m.logger.Debug("getIntentForRoom: ghost PL too low, using bot intent",
 			"room_id", roomID, "ghost_pl", pl)
 	} else {
-		m.logger.Debug("getIntentForRoom: no ghost user found, admin-joining bot",
+		m.logger.Debug("getIntentForRoom: no ghost user found, using bot intent",
 			"room_id", roomID)
-	}
-	if err := m.admin.JoinRoom(ctx, roomID, m.as.BotMXID()); err != nil {
-		m.logger.Debug("getIntentForRoom: admin join failed",
-			"room_id", roomID, "error", err)
 	}
 	return botIntent
 }

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -1220,6 +1220,11 @@ func (m *MautrixAdapter) DeleteAlias(ctx context.Context, alias string) error {
 // KickUser kicks a user from a room.
 func (m *MautrixAdapter) KickUser(ctx context.Context, roomID id.RoomID, userID id.UserID, reason string) error {
 	intent := m.getIntentForRoom(ctx, roomID)
+	// KickUser (unlike SendStateEvent) does not call EnsureJoined internally,
+	// so we must ensure the intent is joined before kicking.
+	if err := intent.EnsureJoined(ctx, roomID); err != nil {
+		return fmt.Errorf("failed to ensure joined for kick in room %s: %w", roomID, err)
+	}
 	_, err := intent.KickUser(
 		ctx, roomID, &mautrix.ReqKickUser{
 			UserID: userID,

--- a/internal/infrastructure/matrix/mautrix_admin_test.go
+++ b/internal/infrastructure/matrix/mautrix_admin_test.go
@@ -1336,12 +1336,12 @@ func TestAdminAPI_FindReaction_WrongEmoji(t *testing.T) {
 // getIntentForRoom admin-join fallback (exercises admin.JoinRoom)
 // ============================================================================
 
-func TestAdminAPI_GetIntentForRoom_AdminJoinFallback(t *testing.T) {
+func TestAdminAPI_GetIntentForRoom_NoGhostReturnsBotIntent(t *testing.T) {
 	// Scenario: bot is NOT a member and no ghost users exist.
-	// getIntentForRoom should admin-join the bot as a last resort.
+	// getIntentForRoom should return botIntent without admin-joining
+	// (admin.JoinRoom bypasses StateStore, causing duplicate join events).
 	botIntent := &mockIntentAPI{}
 	mock := &mockAdminAPI{
-		// GetRoomMembers returns members without the bot → bot not in room.
 		getRoomMembersResult: []string{"@other:test.local"},
 	}
 	as := &mockAppserviceAPI{
@@ -1356,15 +1356,12 @@ func TestAdminAPI_GetIntentForRoom_AdminJoinFallback(t *testing.T) {
 		idMapper: domain.NewIDMapper("test.local"),
 		logger:   &adapterMockLogger{},
 	}
-	_ = a.getIntentForRoom(context.Background(), "!room:test.local")
-	if len(mock.joinRoomCalls) != 1 {
-		t.Fatalf("expected 1 admin JoinRoom call, got %d", len(mock.joinRoomCalls))
+	result := a.getIntentForRoom(context.Background(), "!room:test.local")
+	if result != botIntent {
+		t.Error("expected botIntent to be returned")
 	}
-	if mock.joinRoomCalls[0].RoomID != "!room:test.local" {
-		t.Errorf("expected room '!room:test.local', got %q", mock.joinRoomCalls[0].RoomID)
-	}
-	if mock.joinRoomCalls[0].UserID != "@bot:test.local" {
-		t.Errorf("expected user '@bot:test.local', got %q", mock.joinRoomCalls[0].UserID)
+	if len(mock.joinRoomCalls) != 0 {
+		t.Errorf("expected 0 admin JoinRoom calls, got %d", len(mock.joinRoomCalls))
 	}
 }
 

--- a/internal/infrastructure/matrix/mautrix_intent_test.go
+++ b/internal/infrastructure/matrix/mautrix_intent_test.go
@@ -1584,7 +1584,7 @@ func TestGetIntentForRoom_FallbackToGhost(t *testing.T) {
 	assert.Equal(t, ghostIntent, intent, "should return ghost intent when bot is not in room")
 }
 
-func TestGetIntentForRoom_AdminJoinFallback(t *testing.T) {
+func TestGetIntentForRoom_NoGhostReturnsBotWithoutAdminJoin(t *testing.T) {
 	botIntent := &mockIntentAPI{}
 	admin := &mockAdminAPI{
 		// No members at all (or only non-ghost external users)
@@ -1597,8 +1597,8 @@ func TestGetIntentForRoom_AdminJoinFallback(t *testing.T) {
 	a := newFullTestAdapter(as, admin)
 
 	intent := a.getIntentForRoom(context.Background(), "!room:test.local")
-	assert.Equal(t, botIntent, intent, "should return bot intent as last resort after admin-join")
-	assert.Equal(t, 1, len(admin.joinRoomCalls), "should admin-join the bot")
+	assert.Equal(t, botIntent, intent, "should return bot intent without admin-join")
+	assert.Empty(t, admin.joinRoomCalls, "should NOT admin-join (causes DAG corruption)")
 }
 
 // ============================================================================
@@ -2021,7 +2021,7 @@ func TestFindGhostIntentInRoom_MemberFetchError(t *testing.T) {
 	assert.Equal(t, float64(-1), pl)
 }
 
-func TestGetIntentForRoom_LowPLGhost_AdminJoinFallback(t *testing.T) {
+func TestGetIntentForRoom_LowPLGhost_ReturnsBotWithoutAdminJoin(t *testing.T) {
 	botIntent := &mockIntentAPI{}
 	ghostIntent := &mockIntentAPI{}
 	ghostUserID := expectedUserID(testActorID)
@@ -2041,8 +2041,8 @@ func TestGetIntentForRoom_LowPLGhost_AdminJoinFallback(t *testing.T) {
 	a := newFullTestAdapter(as, admin)
 
 	intent := a.getIntentForRoom(context.Background(), "!room:test.local")
-	assert.Equal(t, botIntent, intent, "should admin-join bot when ghost PL < 50")
-	assert.Len(t, admin.joinRoomCalls, 1)
+	assert.Equal(t, botIntent, intent, "should return bot intent when ghost PL < 50")
+	assert.Empty(t, admin.joinRoomCalls, "should NOT admin-join (causes DAG corruption)")
 }
 
 func TestGetIntentForRoom_CustomMinPL(t *testing.T) {


### PR DESCRIPTION
## Summary

Remove `admin.JoinRoom` from `getIntentForRoom` and `redactCanonicalAliasesFromRooms`. Rely on IntentAPI's built-in `EnsureJoined` instead.

## Root cause

`admin.JoinRoom` (Synapse Admin API) bypasses the mautrix StateStore cache. When followed by any IntentAPI method that calls `EnsureJoined` internally (like `SendStateEvent`), the intent doesn't see the bot as already joined and creates a **second join event**. This corrupts the room's event DAG with duplicate `auth_events`, producing:

```
M_FORBIDDEN: Event $xxx has duplicate auth_events for ('m.room.member', '@bot:host'): $a and $b
```

**695 rooms** were corrupted on acc by this pattern. The corruption makes rooms permanently unjoinable via admin API.

## Fix

Remove `admin.JoinRoom` and let `EnsureJoined` (called automatically by `SendStateEvent`) handle joining. This creates a single join event that updates both Synapse and the local StateStore — no desync, no duplicate events.

## Verification

- Confirmed via Synapse DB that corrupted rooms have 4 bot membership events (original join, admin-join, leave, EnsureJoined-join) all from April 7 when the migration ran
- All rooms on acc are local (single homeserver) — `EnsureJoined` works without `admin.JoinRoom`

## Test plan

- [x] `make build` passes
- [x] `make test` — all tests pass (updated 3 tests that expected admin join)
- [x] `make lint` — 0 issues
- [ ] Deploy to acc after DB cleanup
- [ ] Verify alias migration succeeds without creating duplicate events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified Matrix bot room-joining behavior by removing automatic admin-fallback joins and always using the bot intent when no ghost user is available.

* **Bug Fix**
  * Made user removal more reliable by ensuring the bot is joined before attempting a kick.

* **Tests**
  * Updated tests to verify the new join and kick behaviors without admin-join fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->