### PR TITLE
fix: sync StateStore after admin.JoinRoom to prevent duplicate join DAG corruption

### DIFF
--- a/internal/infrastructure/matrix/appservice_api.go
+++ b/internal/infrastructure/matrix/appservice_api.go
@@ -66,6 +66,9 @@ type appserviceAPI interface {
 	Host() *appservice.HostConfig
 	Router() *http.ServeMux
 	Events() <-chan *event.Event
+	// SetMembership updates the StateStore cache for a user's membership in a room.
+	// Must be called after admin.JoinRoom to prevent EnsureJoined from creating duplicate joins.
+	SetMembership(ctx context.Context, roomID id.RoomID, userID id.UserID, membership event.Membership) error
 }
 
 // appserviceWrapper wraps *appservice.AppService to satisfy appserviceAPI.
@@ -112,4 +115,8 @@ func (w *appserviceWrapper) Router() *http.ServeMux {
 
 func (w *appserviceWrapper) Events() <-chan *event.Event {
 	return w.as.Events
+}
+
+func (w *appserviceWrapper) SetMembership(ctx context.Context, roomID id.RoomID, userID id.UserID, membership event.Membership) error {
+	return w.as.StateStore.SetMembership(ctx, roomID, userID, membership)
 }

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -304,6 +304,8 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 		if _, err := botIntent.LeaveRoom(ctx, room.RoomID); err != nil {
 			m.logger.Warn("Failed to leave room after alias cleanup",
 				"room_id", room.RoomID, "error", err)
+		} else {
+			_ = m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipLeave)
 		}
 	}
 
@@ -1212,6 +1214,9 @@ func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID,
 		if err := m.as.SetMembership(ctx, roomID, m.as.BotMXID(), event.MembershipJoin); err != nil {
 			m.logger.Error("getIntentForRoom: failed to sync StateStore after admin join — risk of duplicate join",
 				"room_id", roomID, "error", err)
+			if intent != nil {
+				return intent // fall back to ghost to avoid duplicate-join risk
+			}
 		}
 	}
 	return botIntent

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -287,6 +287,8 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 				"room_id", room.RoomID, "error", err)
 			continue
 		}
+		// Sync StateStore so EnsureJoined (inside SendStateEvent) doesn't duplicate the join.
+		_ = m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipJoin)
 
 		if _, err := botIntent.SendStateEvent(ctx, room.RoomID, event.StateCanonicalAlias, "", map[string]interface{}{}); err != nil {
 			m.logger.Warn("Failed to clear canonical alias",
@@ -1200,6 +1202,13 @@ func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID,
 	if err := m.admin.JoinRoom(ctx, roomID, m.as.BotMXID()); err != nil {
 		m.logger.Debug("getIntentForRoom: admin join failed",
 			"room_id", roomID, "error", err)
+	} else {
+		// Sync the StateStore so EnsureJoined (called by SendStateEvent, etc.)
+		// sees the bot as already joined and doesn't create a duplicate join event.
+		if err := m.as.SetMembership(ctx, roomID, m.as.BotMXID(), event.MembershipJoin); err != nil {
+			m.logger.Debug("getIntentForRoom: failed to sync StateStore",
+				"room_id", roomID, "error", err)
+		}
 	}
 	return botIntent
 }

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -288,7 +288,11 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 			continue
 		}
 		// Sync StateStore so EnsureJoined (inside SendStateEvent) doesn't duplicate the join.
-		_ = m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipJoin)
+		if err := m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipJoin); err != nil {
+			m.logger.Warn("Failed to sync StateStore after join, skipping room to avoid duplicate join",
+				"room_id", room.RoomID, "error", err)
+			continue
+		}
 
 		if _, err := botIntent.SendStateEvent(ctx, room.RoomID, event.StateCanonicalAlias, "", map[string]interface{}{}); err != nil {
 			m.logger.Warn("Failed to clear canonical alias",
@@ -1206,7 +1210,7 @@ func (m *MautrixAdapter) getIntentForRoom(ctx context.Context, roomID id.RoomID,
 		// Sync the StateStore so EnsureJoined (called by SendStateEvent, etc.)
 		// sees the bot as already joined and doesn't create a duplicate join event.
 		if err := m.as.SetMembership(ctx, roomID, m.as.BotMXID(), event.MembershipJoin); err != nil {
-			m.logger.Debug("getIntentForRoom: failed to sync StateStore",
+			m.logger.Error("getIntentForRoom: failed to sync StateStore after admin join — risk of duplicate join",
 				"room_id", roomID, "error", err)
 		}
 	}

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -305,7 +305,10 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 			m.logger.Warn("Failed to leave room after alias cleanup",
 				"room_id", room.RoomID, "error", err)
 		} else {
-			_ = m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipLeave)
+			if err := m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipLeave); err != nil {
+				m.logger.Warn("Failed to sync StateStore after leave",
+					"room_id", room.RoomID, "error", err)
+			}
 		}
 	}
 

--- a/internal/infrastructure/matrix/mautrix_intent_test.go
+++ b/internal/infrastructure/matrix/mautrix_intent_test.go
@@ -276,10 +276,12 @@ func (m *mockIntentAPI) MakeRequest(_ context.Context, method string, httpURL st
 // ============================================================================
 
 type mockAppserviceAPI struct {
-	botIntent        intentAPI
-	intents          map[id.UserID]intentAPI
-	botMXID          id.UserID
-	homeserverDomain string
+	botIntent          intentAPI
+	intents            map[id.UserID]intentAPI
+	botMXID            id.UserID
+	homeserverDomain   string
+	setMembershipCalls []setMembershipCall
+	setMembershipErr   error
 }
 
 var _ appserviceAPI = (*mockAppserviceAPI)(nil)
@@ -306,8 +308,15 @@ func (m *mockAppserviceAPI) HomeserverDomain() string     { return m.homeserverD
 func (m *mockAppserviceAPI) Host() *appservice.HostConfig { return &appservice.HostConfig{} }
 func (m *mockAppserviceAPI) Router() *http.ServeMux       { return http.NewServeMux() }
 func (m *mockAppserviceAPI) Events() <-chan *event.Event  { return make(<-chan *event.Event) }
-func (m *mockAppserviceAPI) SetMembership(_ context.Context, _ id.RoomID, _ id.UserID, _ event.Membership) error {
-	return nil
+func (m *mockAppserviceAPI) SetMembership(_ context.Context, roomID id.RoomID, userID id.UserID, membership event.Membership) error {
+	m.setMembershipCalls = append(m.setMembershipCalls, setMembershipCall{roomID, userID, membership})
+	return m.setMembershipErr
+}
+
+type setMembershipCall struct {
+	RoomID     id.RoomID
+	UserID     id.UserID
+	Membership event.Membership
 }
 
 // ============================================================================
@@ -1602,6 +1611,10 @@ func TestGetIntentForRoom_AdminJoinFallback(t *testing.T) {
 	intent := a.getIntentForRoom(context.Background(), "!room:test.local")
 	assert.Equal(t, botIntent, intent, "should return bot intent as last resort after admin-join")
 	assert.Equal(t, 1, len(admin.joinRoomCalls), "should admin-join the bot")
+	// Verify StateStore was synced to prevent EnsureJoined from creating duplicate join
+	assert.Equal(t, 1, len(as.setMembershipCalls), "should sync StateStore after admin join")
+	assert.Equal(t, id.RoomID("!room:test.local"), as.setMembershipCalls[0].RoomID)
+	assert.Equal(t, event.MembershipJoin, as.setMembershipCalls[0].Membership)
 }
 
 // ============================================================================

--- a/internal/infrastructure/matrix/mautrix_intent_test.go
+++ b/internal/infrastructure/matrix/mautrix_intent_test.go
@@ -306,6 +306,9 @@ func (m *mockAppserviceAPI) HomeserverDomain() string     { return m.homeserverD
 func (m *mockAppserviceAPI) Host() *appservice.HostConfig { return &appservice.HostConfig{} }
 func (m *mockAppserviceAPI) Router() *http.ServeMux       { return http.NewServeMux() }
 func (m *mockAppserviceAPI) Events() <-chan *event.Event  { return make(<-chan *event.Event) }
+func (m *mockAppserviceAPI) SetMembership(_ context.Context, _ id.RoomID, _ id.UserID, _ event.Membership) error {
+	return nil
+}
 
 // ============================================================================
 // Test helper


### PR DESCRIPTION
## Summary

After `admin.JoinRoom` (Synapse Admin API), sync the mautrix StateStore cache by calling `SetMembership(ctx, roomID, botMXID, MembershipJoin)`. This prevents `EnsureJoined` (called internally by `SendStateEvent`, `KickUser`, etc.) from creating a duplicate join event.

Supersedes #47 (different approach — syncs cache instead of removing admin.JoinRoom).

## Root cause

`admin.JoinRoom` bypasses the mautrix StateStore. Subsequent IntentAPI methods call `EnsureJoined` which checks the cache, doesn't see the bot as joined, and creates a **second join event**. This corrupts the room's event DAG with duplicate `auth_events`.

## Fix

- Add `SetMembership` method to `appserviceAPI` interface (backed by `StateStore.SetMembership`)
- Call it after every successful `admin.JoinRoom` in `getIntentForRoom` and `redactCanonicalAliasesFromRooms`
- `EnsureJoined` then sees the cached membership and skips the join

## Test plan

- [x] `make build` passes
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [ ] Deploy and verify no new duplicate membership events created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of room membership state to prevent inconsistencies when the bot joins or leaves rooms, with safer fallback behavior on failures.

* **New Features**
  * Added an explicit membership-update capability so join/leave actions update cached membership state reliably and log failures.

* **Tests**
  * Updated tests to assert membership-sync calls and error handling during join/leave flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->