### PR TITLE
observability: structured logging for startup and migrations

### DIFF
--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -158,12 +158,11 @@ func safePrefix(s string, n int) string {
 
 // Connect initializes the connection to the Matrix homeserver.
 func (m *MautrixAdapter) Connect(ctx context.Context) error {
-	// Step 1: Try to ensure bot is admin (quick path — works on restarts).
+	m.logger.Info("[Connect] Step 1/6: ensuring bot admin status")
 	m.ensureBotAdmin(ctx)
+	m.logger.Info("[Connect] Step 1/6: complete")
 
-	// Step 2: Start the AppService
-	m.logger.Info("Initializing Matrix AppService connection")
-
+	m.logger.Info("[Connect] Step 2/6: starting AppService HTTP listener")
 	go func() {
 		m.as.Start()
 		m.logger.Warn("AppService HTTP server stopped")
@@ -172,31 +171,39 @@ func (m *MautrixAdapter) Connect(ctx context.Context) error {
 	if err := m.waitForServerReady(ctx); err != nil {
 		return fmt.Errorf("appservice failed to start: %w", err)
 	}
+	m.logger.Info("[Connect] Step 2/6: complete")
 
-	// Step 3: Verify bot connection
+	m.logger.Info("[Connect] Step 3/6: verifying bot connection (Whoami)")
 	botIntent := m.as.BotIntent()
 	whoami, err := botIntent.Whoami(ctx)
 	if err != nil {
-		m.logger.Warn("Failed to verify bot connection (Whoami)", "error", err)
+		m.logger.Warn("[Connect] Step 3/6: Whoami failed", "error", err)
 	} else {
-		m.logger.Info("Matrix AppService connected", "user_id", whoami.UserID)
+		m.logger.Info("[Connect] Step 3/6: complete", "user_id", whoami.UserID)
 	}
 
-	// Step 4: Set bot display name (before any room operations, so creation
-	// events show the display name instead of the raw UUID).
+	m.logger.Info("[Connect] Step 4/6: setting bot display name")
 	if m.botDisplayName != "" {
 		botIntent := m.as.BotIntent()
 		if err := botIntent.SetDisplayName(ctx, m.botDisplayName); err != nil {
-			m.logger.Warn("Failed to set bot display name", "display_name", m.botDisplayName, "error", err)
+			m.logger.Warn("[Connect] Step 4/6: SetDisplayName failed (continuing anyway)",
+				"display_name", m.botDisplayName, "error", err)
 		} else {
-			m.logger.Info("Bot display name set", "display_name", m.botDisplayName)
+			m.logger.Info("[Connect] Step 4/6: complete", "display_name", m.botDisplayName)
 		}
+	} else {
+		m.logger.Info("[Connect] Step 4/6: skipped (no display name configured)")
 	}
 
-	// Step 5: Migration cleanup for existing deployments
+	m.logger.Info("[Connect] Step 5/6: running redactCanonicalAliasesFromRooms migration")
 	m.redactCanonicalAliasesFromRooms(ctx)
-	m.leaveBotFromNonSpaceRooms(ctx)
+	m.logger.Info("[Connect] Step 5/6: complete")
 
+	m.logger.Info("[Connect] Step 6/6: running leaveBotFromNonSpaceRooms migration")
+	m.leaveBotFromNonSpaceRooms(ctx)
+	m.logger.Info("[Connect] Step 6/6: complete")
+
+	m.logger.Info("[Connect] all steps complete")
 	return nil
 }
 
@@ -265,15 +272,28 @@ func (m *MautrixAdapter) ensureBotAdmin(ctx context.Context) {
 // This is a migration cleanup for existing deployments where canonical alias
 // was set, causing clients to show UUID aliases instead of member names.
 func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
+	m.logger.Info("redactCanonicalAliasesFromRooms: listing rooms")
 	rooms, err := m.admin.ListRooms(ctx, 10000)
 	if err != nil {
 		m.logger.Warn("Failed to list rooms for canonical alias cleanup", "error", err)
 		return
 	}
+	m.logger.Info("redactCanonicalAliasesFromRooms: rooms listed", "total_rooms", len(rooms))
+
+	// Pre-filter to find rooms that actually need processing
+	toProcess := 0
+	for _, room := range rooms {
+		if room.RoomType != "m.space" && room.CanonicalAlias != "" &&
+			m.idMapper.AlkemioRoomID(room.CanonicalAlias) != uuid.Nil {
+			toProcess++
+		}
+	}
+	m.logger.Info("redactCanonicalAliasesFromRooms: candidates to process", "count", toProcess)
 
 	redactedCount := 0
-	botIntent := m.as.BotIntent()
-	botMXID := m.as.BotMXID()
+	skippedCount := 0
+	failedCount := 0
+	processed := 0
 
 	for _, room := range rooms {
 		if room.RoomType == "m.space" || room.CanonicalAlias == "" ||
@@ -281,40 +301,72 @@ func (m *MautrixAdapter) redactCanonicalAliasesFromRooms(ctx context.Context) {
 			continue
 		}
 
-		// Join bot via admin API (bypasses join rules), clear alias, then leave.
-		if err := m.admin.JoinRoom(ctx, room.RoomID, botMXID); err != nil {
-			m.logger.Warn("Failed to join room for alias cleanup",
-				"room_id", room.RoomID, "error", err)
-			continue
-		}
-		// Sync StateStore so EnsureJoined (inside SendStateEvent) doesn't duplicate the join.
-		if err := m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipJoin); err != nil {
-			m.logger.Warn("Failed to sync StateStore after join, skipping room to avoid duplicate join",
-				"room_id", room.RoomID, "error", err)
-			continue
+		processed++
+		if processed%50 == 0 {
+			m.logger.Info("redactCanonicalAliasesFromRooms: progress",
+				"processed", processed, "total", toProcess,
+				"redacted", redactedCount, "skipped", skippedCount, "failed", failedCount)
 		}
 
-		if _, err := botIntent.SendStateEvent(ctx, room.RoomID, event.StateCanonicalAlias, "", map[string]interface{}{}); err != nil {
-			m.logger.Warn("Failed to clear canonical alias",
-				"room_id", room.RoomID, "error", err)
-		} else {
+		outcome := m.redactCanonicalAliasInRoom(ctx, room.RoomID)
+		switch outcome {
+		case aliasRedacted:
 			redactedCount++
-		}
-
-		if _, err := botIntent.LeaveRoom(ctx, room.RoomID); err != nil {
-			m.logger.Warn("Failed to leave room after alias cleanup",
-				"room_id", room.RoomID, "error", err)
-		} else {
-			if err := m.as.SetMembership(ctx, room.RoomID, botMXID, event.MembershipLeave); err != nil {
-				m.logger.Warn("Failed to sync StateStore after leave",
-					"room_id", room.RoomID, "error", err)
-			}
+		case aliasSkipped:
+			skippedCount++
+		case aliasFailed:
+			failedCount++
 		}
 	}
 
-	if redactedCount > 0 {
-		m.logger.Info("Redacted canonical aliases (migration cleanup)", "rooms_redacted", redactedCount)
+	m.logger.Info("redactCanonicalAliasesFromRooms: done",
+		"total_candidates", toProcess,
+		"processed", processed,
+		"redacted", redactedCount,
+		"skipped", skippedCount,
+		"failed", failedCount)
+}
+
+type aliasRedactOutcome int
+
+const (
+	aliasRedacted aliasRedactOutcome = iota
+	aliasSkipped
+	aliasFailed
+)
+
+// redactCanonicalAliasInRoom joins the bot, clears the canonical alias, then leaves.
+func (m *MautrixAdapter) redactCanonicalAliasInRoom(ctx context.Context, roomID id.RoomID) aliasRedactOutcome {
+	botIntent := m.as.BotIntent()
+	botMXID := m.as.BotMXID()
+
+	if err := m.admin.JoinRoom(ctx, roomID, botMXID); err != nil {
+		m.logger.Warn("Failed to join room for alias cleanup",
+			"room_id", roomID, "error", err)
+		return aliasFailed
 	}
+	if err := m.as.SetMembership(ctx, roomID, botMXID, event.MembershipJoin); err != nil {
+		m.logger.Warn("Failed to sync StateStore after join, skipping room to avoid duplicate join",
+			"room_id", roomID, "error", err)
+		return aliasSkipped
+	}
+
+	outcome := aliasRedacted
+	if _, err := botIntent.SendStateEvent(ctx, roomID, event.StateCanonicalAlias, "", map[string]interface{}{}); err != nil {
+		m.logger.Warn("Failed to clear canonical alias",
+			"room_id", roomID, "error", err)
+		outcome = aliasFailed
+	}
+
+	if _, err := botIntent.LeaveRoom(ctx, roomID); err != nil {
+		m.logger.Warn("Failed to leave room after alias cleanup",
+			"room_id", roomID, "error", err)
+	} else if err := m.as.SetMembership(ctx, roomID, botMXID, event.MembershipLeave); err != nil {
+		m.logger.Warn("Failed to sync StateStore after leave",
+			"room_id", roomID, "error", err)
+	}
+
+	return outcome
 }
 
 // findGhostIntentInRoom finds the ghost user with the highest power level in a room.
@@ -368,29 +420,43 @@ func (m *MautrixAdapter) findGhostIntentInRoom(ctx context.Context, roomID id.Ro
 
 // leaveBotFromNonSpaceRooms removes the bot from all rooms that are not spaces.
 func (m *MautrixAdapter) leaveBotFromNonSpaceRooms(ctx context.Context) {
+	m.logger.Info("leaveBotFromNonSpaceRooms: fetching joined rooms")
 	intent := m.as.BotIntent()
 	resp, err := intent.JoinedRooms(ctx)
 	if err != nil {
 		m.logger.Warn("Failed to get bot's joined rooms for cleanup", "error", err)
 		return
 	}
+	m.logger.Info("leaveBotFromNonSpaceRooms: joined rooms fetched",
+		"total_joined", len(resp.JoinedRooms))
 
 	leftCount := 0
-	for _, roomID := range resp.JoinedRooms {
+	skippedSpaces := 0
+	failedCount := 0
+	for i, roomID := range resp.JoinedRooms {
+		if i > 0 && i%50 == 0 {
+			m.logger.Info("leaveBotFromNonSpaceRooms: progress",
+				"processed", i, "total", len(resp.JoinedRooms),
+				"left", leftCount, "skipped_spaces", skippedSpaces, "failed", failedCount)
+		}
 		if isSpace, _ := m.isSpaceRoom(ctx, roomID); isSpace {
+			skippedSpaces++
 			continue
 		}
 		if _, err := intent.LeaveRoom(ctx, roomID); err != nil {
 			m.logger.Warn("Failed to leave room during cleanup",
 				"room_id", roomID, "error", err)
+			failedCount++
 		} else {
 			leftCount++
 		}
 	}
 
-	if leftCount > 0 {
-		m.logger.Info("Bot left non-space rooms (migration cleanup)", "rooms_left", leftCount)
-	}
+	m.logger.Info("leaveBotFromNonSpaceRooms: done",
+		"total_joined", len(resp.JoinedRooms),
+		"left", leftCount,
+		"skipped_spaces", skippedSpaces,
+		"failed", failedCount)
 }
 
 // waitForSynapse retries connecting to Synapse until it responds or context is cancelled.


### PR DESCRIPTION
## Summary

- Add `[Connect] Step N/6` markers to every step in the Connect() flow
- Add progress logging every 50 rooms during migrations
- Always log final summary with counts (redacted/skipped/failed)
- Extract per-room alias redaction into helper to satisfy gocyclo

## Why

The existing migration code was completely silent during processing and only logged a final message if `redactedCount > 0`. This made debugging stuck startups impossible — you couldn't tell which step was hanging or how far the migration had progressed.

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced system initialization with structured logging for better visibility into startup process
  * Implemented automated maintenance operations with progress tracking and detailed completion reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->