### PR TITLE
chore: link CLAUDE.md to alkemio-workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # matrix-adapter-go Development Guidelines
 
+> **Workspace context.** This repo is part of the Alkemio polyrepo at
+> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
+> working on a `feat/NNN-...` branch in this repo, the matching workspace
+> spec is the single source of truth.
+
 Auto-generated from all feature plans. Last updated: 2026-03-07
 
 ## Active Technologies


### PR DESCRIPTION
Adds a small **Workspace context** blockquote to `CLAUDE.md` so future Claude
sessions opened in this repo know that cross-repo (vertical) feature specs
live in [`alkem-io/alkemio-workspace`](https://github.com/alkem-io/alkemio-workspace).

No behaviour change. Documentation only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation with workspace context information, including details about the polyrepo structure and cross-repository specification guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/matrix-adapter-go/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->