### PR TITLE
chore(synapse): add workflow to sync alkemio_room_control.py + registration.yaml to downstreams

### DIFF
--- a/.github/workflows/sync-synapse-module.yml
+++ b/.github/workflows/sync-synapse-module.yml
@@ -1,16 +1,27 @@
-name: Sync Synapse Module to Downstream Repos
+name: Sync Synapse Config to Downstream Repos
 
-# When the canonical Synapse module (synapse-modules/alkemio_room_control.py)
-# changes on develop, this workflow propagates the new version to the three
-# downstream repos that embed or vendor it:
+# Propagates two canonical Synapse-related files from this repo to the three
+# downstream repos whenever they change on develop:
 #
-#   - alkem-io/server                     →  .build/synapse/modules/alkemio_room_control.py
-#   - alkem-io/dev-orchestration          →  ConfigMap literal block (k8s dev env)
-#   - alkem-io/infrastructure-operations  →  ConfigMap literal block (k8s prod/acceptance)
+#   synapse-modules/alkemio_room_control.py   (the Synapse room-control module)
+#   registration.yaml                          (the AppService registration shape)
 #
-# Each target gets a single rolling PR on branch
-# `bot/sync-alkemio-room-control-module`; re-running this workflow updates
-# that PR's diff in-place rather than opening new PRs.
+# Targets:
+#
+#   - alkem-io/server                     (file mode)
+#   - alkem-io/dev-orchestration          (embedded in 01-synapse-setup-confmap.yml)
+#   - alkem-io/infrastructure-operations  (embedded in 01-synapse-setup-confmap.yml)
+#
+# The room-control module is synced verbatim (it has no per-environment
+# fields). registration.yaml is schema-synced: namespaces / sender_localpart /
+# receive_ephemeral / msc2409 / id are taken from canonical, but each target's
+# existing url / as_token / hs_token values are preserved (those are
+# environment-specific — dev secrets in server, ${MATRIX_*} placeholders in
+# the ops repos).
+#
+# Each target gets a single rolling PR on branch `bot/sync-synapse-config`;
+# re-running this workflow updates that PR's diff in-place rather than
+# opening new PRs. Both files' changes land in one PR when both are out of sync.
 #
 # Required secrets (configured in matrix-adapter-go):
 #
@@ -30,12 +41,14 @@ on:
     branches: [develop]
     paths:
       - 'synapse-modules/alkemio_room_control.py'
+      - 'registration.yaml'
       - '.scripts/sync-synapse-module.sh'
+      - '.scripts/sync-synapse-registration.py'
       - '.github/workflows/sync-synapse-module.yml'
   workflow_dispatch: {}
 
 concurrency:
-  group: sync-synapse-module-${{ github.ref }}
+  group: sync-synapse-config-${{ github.ref }}
   cancel-in-progress: false
 
 permissions: {}
@@ -54,7 +67,7 @@ jobs:
           - repo: alkem-io/infrastructure-operations
             base: develop
     env:
-      SYNC_BRANCH: bot/sync-alkemio-room-control-module
+      SYNC_BRANCH: bot/sync-synapse-config
       TARGET_REPO: ${{ matrix.target.repo }}
       TARGET_BASE: ${{ matrix.target.base }}
 
@@ -73,11 +86,16 @@ jobs:
           ref: ${{ matrix.target.base }}
           fetch-depth: 0
 
-      - name: Apply sync
+      - name: Apply room-control module sync
+        run: ./source/.scripts/sync-synapse-module.sh ./target
+
+      - name: Apply registration.yaml sync
+        run: ./source/.scripts/sync-synapse-registration.py ./target
+
+      - name: Detect changes
         id: sync
         run: |
           set -euo pipefail
-          ./source/.scripts/sync-synapse-module.sh ./target
           cd target
           if [[ -n "$(git status --porcelain)" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -132,9 +150,13 @@ jobs:
 
           git checkout -B "$SYNC_BRANCH"
           git add -A
-          git commit -S -m "chore(synapse): sync alkemio_room_control.py from matrix-adapter-go@${SOURCE_SHA:0:7}
+          git commit -S -m "chore(synapse): sync canonical config from matrix-adapter-go@${SOURCE_SHA:0:7}
 
-          Auto-synced from https://github.com/${{ github.repository }}/commit/${SOURCE_SHA}"
+          Auto-synced from https://github.com/${{ github.repository }}/commit/${SOURCE_SHA}
+
+          Files synced from matrix-adapter-go:
+            synapse-modules/alkemio_room_control.py
+            registration.yaml (schema fields only; url / as_token / hs_token preserved)"
 
           git push --force-with-lease \
             "https://x-access-token:${PUSH_TOKEN}@github.com/${TARGET_REPO}.git" \
@@ -153,11 +175,14 @@ jobs:
             const base = process.env.TARGET_BASE;
             const sourceSha = process.env.SOURCE_SHA;
             const shortSha = sourceSha.slice(0, 7);
-            const title = `chore(synapse): sync alkemio_room_control.py from matrix-adapter-go`;
+            const title = `chore(synapse): sync canonical config from matrix-adapter-go`;
             const body = [
               `Auto-synced from [matrix-adapter-go@${shortSha}](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sourceSha}).`,
               '',
-              'The canonical `alkemio_room_control.py` lives in [matrix-adapter-go/synapse-modules/](https://github.com/alkem-io/matrix-adapter-go/blob/develop/synapse-modules/alkemio_room_control.py). This PR is opened and updated automatically by the `sync-synapse-module` workflow whenever that file changes on `develop`.',
+              'Two canonical Synapse-related files live in matrix-adapter-go and are propagated here automatically:',
+              '',
+              '- [`synapse-modules/alkemio_room_control.py`](https://github.com/alkem-io/matrix-adapter-go/blob/develop/synapse-modules/alkemio_room_control.py) — synced verbatim.',
+              '- [`registration.yaml`](https://github.com/alkem-io/matrix-adapter-go/blob/develop/registration.yaml) — schema fields only; `url` / `as_token` / `hs_token` are preserved from this repo.',
               '',
               `Review and merge to roll the change forward to this repo's deployment. The branch (\`${branch}\`) is rolling — subsequent canonical changes will force-update this PR rather than open new ones.`,
             ].join('\n');

--- a/.github/workflows/sync-synapse-module.yml
+++ b/.github/workflows/sync-synapse-module.yml
@@ -1,0 +1,181 @@
+name: Sync Synapse Module to Downstream Repos
+
+# When the canonical Synapse module (synapse-modules/alkemio_room_control.py)
+# changes on develop, this workflow propagates the new version to the three
+# downstream repos that embed or vendor it:
+#
+#   - alkem-io/server                     →  .build/synapse/modules/alkemio_room_control.py
+#   - alkem-io/dev-orchestration          →  ConfigMap literal block (k8s dev env)
+#   - alkem-io/infrastructure-operations  →  ConfigMap literal block (k8s prod/acceptance)
+#
+# Each target gets a single rolling PR on branch
+# `bot/sync-alkemio-room-control-module`; re-running this workflow updates
+# that PR's diff in-place rather than opening new PRs.
+#
+# Required secrets (configured in matrix-adapter-go):
+#
+#   ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN       PAT for the bot account with
+#                                               contents:write + pull_requests:write
+#                                               on the three downstream repos.
+#   ALKEMIO_INFRASTRUCTURE_BOT_GPG_PRIVATE_KEY  ASCII-armoured GPG private key for
+#                                               signing commits.
+#   ALKEMIO_INFRASTRUCTURE_BOT_GPG_PASSPHRASE   Passphrase for the GPG key.
+#   ALKEMIO_INFRASTRUCTURE_BOT_GPG_KEY_ID       Fallback key ID if the import action
+#                                               doesn't surface a fingerprint.
+#
+# Same secrets are used by server/.github/workflows/schema-baseline.yml.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'synapse-modules/alkemio_room_control.py'
+      - '.scripts/sync-synapse-module.sh'
+      - '.github/workflows/sync-synapse-module.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: sync-synapse-module-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - repo: alkem-io/server
+            base: develop
+          - repo: alkem-io/dev-orchestration
+            base: main
+          - repo: alkem-io/infrastructure-operations
+            base: develop
+    env:
+      SYNC_BRANCH: bot/sync-alkemio-room-control-module
+      TARGET_REPO: ${{ matrix.target.repo }}
+      TARGET_BASE: ${{ matrix.target.base }}
+
+    steps:
+      - name: Checkout matrix-adapter-go (canonical)
+        uses: actions/checkout@v4
+        with:
+          path: source
+
+      - name: Checkout ${{ matrix.target.repo }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.target.repo }}
+          token: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN }}
+          path: target
+          ref: ${{ matrix.target.base }}
+          fetch-depth: 0
+
+      - name: Apply sync
+        id: sync
+        run: |
+          set -euo pipefail
+          ./source/.scripts/sync-synapse-module.sh ./target
+          cd target
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --stat
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate downstream YAML still parses
+        if: steps.sync.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import sys, glob, yaml
+          for path in glob.glob("target/**/01-synapse-setup-confmap.yml", recursive=True):
+              with open(path) as f:
+                  yaml.safe_load(f)
+              print(f"OK: {path}")
+          PY
+
+      - name: Import GPG signing key
+        if: steps.sync.outputs.changed == 'true'
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_GPG_PASSPHRASE }}
+          trust_level: 5
+          workdir: target
+
+      - name: Commit and push sync branch
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          PUSH_TOKEN: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          FALLBACK_GPG_KEY_ID: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_GPG_KEY_ID }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -Eeuo pipefail
+          cd target
+          git config user.name "Alkemio Infrastructure Bot"
+          git config user.email "infrastructure@alkem.io"
+          git config commit.gpgsign true
+          if [[ -n "${GPG_FINGERPRINT:-}" ]]; then
+            git config user.signingkey "$GPG_FINGERPRINT"
+          elif [[ -n "${FALLBACK_GPG_KEY_ID:-}" ]]; then
+            git config user.signingkey "$FALLBACK_GPG_KEY_ID"
+          else
+            echo "::error::No GPG signing key available." >&2
+            exit 1
+          fi
+
+          git checkout -B "$SYNC_BRANCH"
+          git add -A
+          git commit -S -m "chore(synapse): sync alkemio_room_control.py from matrix-adapter-go@${SOURCE_SHA:0:7}
+
+          Auto-synced from https://github.com/${{ github.repository }}/commit/${SOURCE_SHA}"
+
+          git push --force-with-lease \
+            "https://x-access-token:${PUSH_TOKEN}@github.com/${TARGET_REPO}.git" \
+            "${SYNC_BRANCH}"
+
+      - name: Open or update pull request
+        if: steps.sync.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        with:
+          github-token: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN }}
+          script: |
+            const [owner, repo] = process.env.TARGET_REPO.split('/');
+            const branch = process.env.SYNC_BRANCH;
+            const base = process.env.TARGET_BASE;
+            const sourceSha = process.env.SOURCE_SHA;
+            const shortSha = sourceSha.slice(0, 7);
+            const title = `chore(synapse): sync alkemio_room_control.py from matrix-adapter-go`;
+            const body = [
+              `Auto-synced from [matrix-adapter-go@${shortSha}](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sourceSha}).`,
+              '',
+              'The canonical `alkemio_room_control.py` lives in [matrix-adapter-go/synapse-modules/](https://github.com/alkem-io/matrix-adapter-go/blob/develop/synapse-modules/alkemio_room_control.py). This PR is opened and updated automatically by the `sync-synapse-module` workflow whenever that file changes on `develop`.',
+              '',
+              `Review and merge to roll the change forward to this repo's deployment. The branch (\`${branch}\`) is rolling — subsequent canonical changes will force-update this PR rather than open new ones.`,
+            ].join('\n');
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner, repo, state: 'open',
+              head: `${owner}:${branch}`,
+              base,
+            });
+
+            if (existing.length > 0) {
+              const pr = existing[0];
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, title, body });
+              core.info(`Updated existing PR #${pr.number}: ${pr.html_url}`);
+            } else {
+              const { data: pr } = await github.rest.pulls.create({
+                owner, repo, head: branch, base, title, body,
+                maintainer_can_modify: true,
+              });
+              core.info(`Opened PR #${pr.number}: ${pr.html_url}`);
+            }

--- a/.github/workflows/sync-synapse-module.yml
+++ b/.github/workflows/sync-synapse-module.yml
@@ -55,6 +55,11 @@ permissions: {}
 
 jobs:
   sync:
+    # Guard against manual dispatches from feature branches: the source checkout
+    # below has no explicit ref, so it'd otherwise pull canonical content from
+    # whatever branch the dispatch was fired from. We only ever want to sync
+    # what's actually on develop.
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -76,6 +81,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: source
+          persist-credentials: false
 
       - name: Checkout ${{ matrix.target.repo }}
         uses: actions/checkout@v4
@@ -109,11 +115,16 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
-          import sys, glob, yaml
-          for path in glob.glob("target/**/01-synapse-setup-confmap.yml", recursive=True):
-              with open(path) as f:
-                  yaml.safe_load(f)
-              print(f"OK: {path}")
+          import glob, yaml
+          patterns = (
+              "target/**/01-synapse-setup-confmap.yml",   # ops repos
+              "target/**/matrix-adapter.yaml",            # server's registration file
+          )
+          for pattern in patterns:
+              for path in glob.glob(pattern, recursive=True):
+                  with open(path) as f:
+                      yaml.safe_load(f)
+                  print(f"OK: {path}")
           PY
 
       - name: Import GPG signing key

--- a/.scripts/sync-synapse-module.sh
+++ b/.scripts/sync-synapse-module.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Sync the canonical Synapse AlkemioRoomControl module into a downstream repo.
+#
+# Source of truth:
+#   matrix-adapter-go/synapse-modules/alkemio_room_control.py
+#
+# Downstream layouts handled:
+#
+#   file mode   — server
+#     <repo>/.build/synapse/modules/alkemio_room_control.py
+#       → overwritten verbatim with the canonical file.
+#
+#   embed mode  — dev-orchestration, infrastructure-operations
+#     <repo>/01-alkemio-platform/base/third-party/communication/synapse/01-synapse-setup-confmap.yml
+#     <repo>/orchestration/base/third-party/communication/synapse/01-synapse-setup-confmap.yml
+#       → the YAML literal block under the `alkemio_room_control.py: |`
+#         key in `data:` is replaced with the canonical content, indented
+#         by 4 spaces (so it nests under `data:` properly). The literal
+#         block is assumed to be the LAST data key in the ConfigMap; the
+#         script aborts if another data key appears after it.
+#
+# Usage:
+#   sync-synapse-module.sh <target-repo-root>
+#
+# Exit codes:
+#   0  — change applied OR no change needed (idempotent)
+#   2  — canonical source missing
+#   3  — target layout not recognised
+#   4  — embed-mode marker not found
+#   5  — another data key follows the module block (script needs updating)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CANONICAL="$REPO_ROOT/synapse-modules/alkemio_room_control.py"
+
+if [[ ! -f "$CANONICAL" ]]; then
+  echo "ERROR: canonical source not found at $CANONICAL" >&2
+  exit 2
+fi
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <target-repo-root>" >&2
+  exit 2
+fi
+
+TARGET="$(cd "$1" && pwd)"
+
+DEV_ORCH_CONFMAP="$TARGET/01-alkemio-platform/base/third-party/communication/synapse/01-synapse-setup-confmap.yml"
+INFRA_OPS_CONFMAP="$TARGET/orchestration/base/third-party/communication/synapse/01-synapse-setup-confmap.yml"
+SERVER_MODULE="$TARGET/.build/synapse/modules/alkemio_room_control.py"
+
+if [[ -f "$SERVER_MODULE" ]]; then
+  MODE=file
+  DEST="$SERVER_MODULE"
+elif [[ -f "$DEV_ORCH_CONFMAP" ]]; then
+  MODE=embed
+  DEST="$DEV_ORCH_CONFMAP"
+elif [[ -f "$INFRA_OPS_CONFMAP" ]]; then
+  MODE=embed
+  DEST="$INFRA_OPS_CONFMAP"
+else
+  echo "ERROR: $TARGET does not match any known downstream layout" >&2
+  echo "  expected one of:" >&2
+  echo "    $SERVER_MODULE" >&2
+  echo "    $DEV_ORCH_CONFMAP" >&2
+  echo "    $INFRA_OPS_CONFMAP" >&2
+  exit 3
+fi
+
+if [[ "$MODE" == file ]]; then
+  if cmp -s "$CANONICAL" "$DEST"; then
+    echo "no change: $DEST"
+    exit 0
+  fi
+  cp "$CANONICAL" "$DEST"
+  echo "updated: $DEST"
+  exit 0
+fi
+
+# embed mode
+KEY_LINE="$(grep -n '^  alkemio_room_control.py: |$' "$DEST" | head -1 | cut -d: -f1 || true)"
+if [[ -z "${KEY_LINE:-}" ]]; then
+  echo "ERROR: marker '  alkemio_room_control.py: |' not found in $DEST" >&2
+  exit 4
+fi
+
+NEXT_KEY="$(awk -v start="$KEY_LINE" 'NR > start && /^  [A-Za-z_][A-Za-z0-9_.-]*:/ { print NR; exit }' "$DEST" || true)"
+if [[ -n "${NEXT_KEY:-}" ]]; then
+  echo "ERROR: another ConfigMap data key appears at line $NEXT_KEY (after the module block)." >&2
+  echo "       This script assumes alkemio_room_control.py is the last key in data; please update it." >&2
+  exit 5
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+head -n "$KEY_LINE" "$DEST" > "$TMP"
+# Indent by 4 spaces; on otherwise-blank lines, leave them truly blank
+# (matches the existing infra-ops style and produces deterministic output).
+sed -e 's/^/    /' -e 's/^    $//' "$CANONICAL" >> "$TMP"
+
+if cmp -s "$TMP" "$DEST"; then
+  echo "no change: $DEST"
+  exit 0
+fi
+
+mv "$TMP" "$DEST"
+trap - EXIT
+echo "updated: $DEST"

--- a/.scripts/sync-synapse-registration.py
+++ b/.scripts/sync-synapse-registration.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Sync the canonical Synapse AppService registration shape into a downstream repo.
+
+Source of truth:
+  matrix-adapter-go/registration.yaml
+
+Downstream layouts:
+
+  file mode — server
+    <target>/.build/synapse/matrix-adapter.yaml
+      Overwritten with canonical content, except url / as_token / hs_token
+      which are preserved from the current file (these are dev secrets,
+      not part of the schema).
+
+  printf-block mode — dev-orchestration, infrastructure-operations
+    <target>/01-alkemio-platform/base/third-party/communication/synapse/01-synapse-setup-confmap.yml
+    <target>/orchestration/base/third-party/communication/synapse/01-synapse-setup-confmap.yml
+      The shell heredoc that emits /data/matrix-adapter.yaml at pod startup
+      is regenerated from canonical, preserving the existing url /
+      ${MATRIX_AS_TOKEN} / ${MATRIX_HS_TOKEN} lines.
+
+Schema fields are taken from canonical; url / as_token / hs_token are taken
+from the target. Comments and blank lines in canonical are dropped (the
+output doesn't have a natural place for them).
+
+Usage:
+  sync-synapse-registration.py <target-repo-root>
+
+Exit codes:
+  0 — change applied OR no change needed
+  2 — usage error / canonical missing
+  3 — target layout not recognised
+  4 — printf-block markers not found in target
+"""
+
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+CANONICAL = REPO_ROOT / "registration.yaml"
+
+PRESERVED_FIELDS = ("url", "as_token", "hs_token")
+
+
+def detect_target(root: Path):
+    server = root / ".build" / "synapse" / "matrix-adapter.yaml"
+    dev_orch = (
+        root
+        / "01-alkemio-platform/base/third-party/communication/synapse/01-synapse-setup-confmap.yml"
+    )
+    infra_ops = (
+        root
+        / "orchestration/base/third-party/communication/synapse/01-synapse-setup-confmap.yml"
+    )
+    if server.exists():
+        return "file", server
+    if dev_orch.exists():
+        return "printf", dev_orch
+    if infra_ops.exists():
+        return "printf", infra_ops
+    print(f"ERROR: {root} does not match any known downstream layout", file=sys.stderr)
+    for p in (server, dev_orch, infra_ops):
+        print(f"  expected one of: {p}", file=sys.stderr)
+    sys.exit(3)
+
+
+def get_field_value(yaml_text: str, field: str) -> str | None:
+    """Return the verbatim VALUE portion of a top-level `field: VALUE` line."""
+    pattern = re.compile(rf"^{re.escape(field)}:\s+(.+?)\s*$", re.MULTILINE)
+    m = pattern.search(yaml_text)
+    return m.group(1) if m else None
+
+
+def strip_leading_comment_block(text: str) -> str:
+    """Drop the contiguous comment/blank lines at the top of a YAML file.
+
+    Comments inside the body are preserved — only the front-matter block,
+    which is canonical-only metadata ("this file is auto-synced…"), is removed.
+    """
+    lines = text.splitlines(keepends=True)
+    idx = 0
+    while idx < len(lines):
+        stripped = lines[idx].lstrip()
+        if stripped.startswith("#") or stripped == "" or stripped == "\n":
+            idx += 1
+            continue
+        break
+    return "".join(lines[idx:])
+
+
+def sync_file_mode(canonical_text: str, target: Path) -> bool:
+    target_text = target.read_text()
+    preserved = {f: get_field_value(target_text, f) for f in PRESERVED_FIELDS}
+    new_text = strip_leading_comment_block(canonical_text)
+    for field, value in preserved.items():
+        if value is None:
+            continue
+        new_text = re.sub(
+            rf"^{re.escape(field)}:.*$",
+            f"{field}: {value}",
+            new_text,
+            count=1,
+            flags=re.MULTILINE,
+        )
+    if new_text == target_text:
+        print(f"no change: {target}")
+        return False
+    target.write_text(new_text)
+    print(f"updated: {target}")
+    return True
+
+
+def shell_quote(line: str) -> str:
+    """Wrap a YAML line in shell quoting for use as a printf argument.
+
+    Use single quotes if the line contains `"`; double quotes otherwise so
+    `${VAR}` interpolation still works.
+    """
+    if '"' in line:
+        if "'" in line:
+            raise ValueError(
+                f"cannot shell-quote line with both quote kinds: {line!r}"
+            )
+        return f"'{line}'"
+    return f'"{line}"'
+
+
+def extract_printf_block(text: str) -> tuple[str, int, int, str]:
+    """Return (block_indent, body_start, body_end, body_text).
+
+    body_text spans from just after the `printf '%s\\n' \\` line through
+    just before the `> /data/matrix-adapter.yaml` line.
+    """
+    start_match = re.search(
+        r"^(\s+)printf\s+'%s\\n'\s*\\\s*$", text, re.MULTILINE
+    )
+    if not start_match:
+        print("ERROR: printf '%s\\n' \\ start marker not found", file=sys.stderr)
+        sys.exit(4)
+    block_indent = start_match.group(1)
+    body_start = start_match.end() + 1  # skip the newline after the marker
+
+    end_marker = "> /data/matrix-adapter.yaml"
+    end_idx = text.find(end_marker, body_start)
+    if end_idx == -1:
+        print(
+            f"ERROR: '{end_marker}' end marker not found", file=sys.stderr
+        )
+        sys.exit(4)
+    body_end = text.rfind("\n", 0, end_idx) + 1
+    return block_indent, body_start, body_end, text[body_start:body_end]
+
+
+def extract_preserved_lines(body: str) -> dict[str, str]:
+    """Pull the existing url / as_token / hs_token VALUE portions out of the
+    printf block so we can re-emit them unchanged.
+    """
+    preserved: dict[str, str] = {}
+    for field in PRESERVED_FIELDS:
+        # Each shell line looks like:   "field: VALUE" \   or   'field: VALUE' \
+        pattern = re.compile(
+            rf'^\s+["\']{re.escape(field)}:\s+(.+?)["\']\s*\\\s*$',
+            re.MULTILINE,
+        )
+        m = pattern.search(body)
+        if m:
+            preserved[field] = m.group(1)
+    return preserved
+
+
+def sync_printf_mode(canonical_text: str, target: Path) -> bool:
+    target_text = target.read_text()
+    block_indent, body_start, body_end, existing_body = extract_printf_block(
+        target_text
+    )
+    preserved = extract_preserved_lines(existing_body)
+
+    string_indent = block_indent + "  "
+    new_lines: list[str] = []
+    for raw in canonical_text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        top_field = re.match(r"^([A-Za-z_][A-Za-z0-9_.-]*):", line)
+        if top_field and top_field.group(1) in PRESERVED_FIELDS:
+            field = top_field.group(1)
+            if field in preserved:
+                line = f"{field}: {preserved[field]}"
+        new_lines.append(f"{string_indent}{shell_quote(line)} \\")
+
+    new_body = "\n".join(new_lines) + "\n"
+    new_text = target_text[:body_start] + new_body + target_text[body_end:]
+
+    if new_text == target_text:
+        print(f"no change: {target}")
+        return False
+    target.write_text(new_text)
+    print(f"updated: {target}")
+    return True
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <target-repo-root>", file=sys.stderr)
+        return 2
+    if not CANONICAL.exists():
+        print(f"ERROR: canonical not found at {CANONICAL}", file=sys.stderr)
+        return 2
+
+    target_root = Path(sys.argv[1]).resolve()
+    canonical_text = CANONICAL.read_text()
+    mode, dest = detect_target(target_root)
+    if mode == "file":
+        sync_file_mode(canonical_text, dest)
+    else:
+        sync_printf_mode(canonical_text, dest)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.scripts/sync-synapse-registration.py
+++ b/.scripts/sync-synapse-registration.py
@@ -116,16 +116,19 @@ def sync_file_mode(canonical_text: str, target: Path) -> bool:
 def shell_quote(line: str) -> str:
     """Wrap a YAML line in shell quoting for use as a printf argument.
 
-    Use single quotes if the line contains `"`; double quotes otherwise so
-    `${VAR}` interpolation still works.
+    Three cases:
+      - no `"` in the line          → double quotes (preserves `${VAR}` interp)
+      - `"` but no `'`              → single quotes (verbatim)
+      - both `"` and `'` in the line → single quotes with `'` → `'\\''` escape
+        (canonical YAML rarely contains both; this branch only exists so a
+        future canonical change doesn't hard-fail the workflow)
     """
-    if '"' in line:
-        if "'" in line:
-            raise ValueError(
-                f"cannot shell-quote line with both quote kinds: {line!r}"
-            )
+    if '"' not in line:
+        return f'"{line}"'
+    if "'" not in line:
         return f"'{line}'"
-    return f'"{line}"'
+    escaped = line.replace("'", "'\\''")
+    return f"'{escaped}'"
 
 
 def extract_printf_block(text: str) -> tuple[str, int, int, str]:

--- a/registration.yaml
+++ b/registration.yaml
@@ -1,3 +1,7 @@
+# Canonical AppService registration shape. Schema fields are auto-synced to
+# downstream repos by .github/workflows/sync-synapse-module.yml whenever this
+# file changes on develop. The url / as_token / hs_token below are local-dev
+# placeholders only — each downstream preserves its own values for those three.
 id: alkemio-matrix-adapter
 url: http://host.docker.internal:8280
 as_token: secret_as_token
@@ -6,6 +10,7 @@ hs_token: secret_hs_token
 sender_localpart: "00000000-0000-0000-0000-000000000000"
 # Enable receiving ephemeral events (m.receipt for read receipts)
 receive_ephemeral: true
+de.sorunome.msc2409.push_ephemeral: true
 namespaces:
   users:
     # Bot user - exclusive, only AS can control (security: prevents impersonation)

--- a/synapse-modules/README.md
+++ b/synapse-modules/README.md
@@ -2,13 +2,13 @@
 
 This is a Synapse spam checker module that restricts room creation to the Alkemio Matrix Adapter AppService bot.
 
-> **Canonical source.** This file is the single source of truth. Three downstream copies are kept in sync automatically by [`.github/workflows/sync-synapse-module.yml`](../.github/workflows/sync-synapse-module.yml) whenever this file changes on `develop`:
+> **Canonical source.** This file (and [`../registration.yaml`](../registration.yaml)) is the single source of truth. Three downstream copies are kept in sync automatically by [`.github/workflows/sync-synapse-module.yml`](../.github/workflows/sync-synapse-module.yml) whenever either file changes on `develop`:
 >
-> - `alkem-io/server` — `.build/synapse/modules/alkemio_room_control.py`
-> - `alkem-io/dev-orchestration` — embedded in `01-synapse-setup-confmap.yml`
-> - `alkem-io/infrastructure-operations` — embedded in `01-synapse-setup-confmap.yml`
+> - `alkem-io/server` — `.build/synapse/modules/alkemio_room_control.py` + `.build/synapse/matrix-adapter.yaml`
+> - `alkem-io/dev-orchestration` — both embedded in `01-synapse-setup-confmap.yml`
+> - `alkem-io/infrastructure-operations` — both embedded in `01-synapse-setup-confmap.yml`
 >
-> Do not edit those copies directly. Edit this file, merge to `develop`, and review the rolling PR opened in each downstream repo by the Alkemio Infrastructure Bot.
+> Do not edit those copies directly. Edit this file (or `registration.yaml`), merge to `develop`, and review the rolling PR opened in each downstream repo by the Alkemio Infrastructure Bot. For `registration.yaml`, only schema fields are synced — `url`, `as_token`, and `hs_token` stay environment-specific in each downstream.
 
 ## Overview
 

--- a/synapse-modules/README.md
+++ b/synapse-modules/README.md
@@ -2,6 +2,14 @@
 
 This is a Synapse spam checker module that restricts room creation to the Alkemio Matrix Adapter AppService bot.
 
+> **Canonical source.** This file is the single source of truth. Three downstream copies are kept in sync automatically by [`.github/workflows/sync-synapse-module.yml`](../.github/workflows/sync-synapse-module.yml) whenever this file changes on `develop`:
+>
+> - `alkem-io/server` — `.build/synapse/modules/alkemio_room_control.py`
+> - `alkem-io/dev-orchestration` — embedded in `01-synapse-setup-confmap.yml`
+> - `alkem-io/infrastructure-operations` — embedded in `01-synapse-setup-confmap.yml`
+>
+> Do not edit those copies directly. Edit this file, merge to `develop`, and review the rolling PR opened in each downstream repo by the Alkemio Infrastructure Bot.
+
 ## Overview
 
 - **All users are ghost users** provisioned by the AppService


### PR DESCRIPTION
## Summary

Closes alkem-io/infrastructure-operations#2228.

Adds an automated cross-repo sync so the canonical Synapse-related files in this repo no longer drift from the three downstream copies. This is the root-cause fix for the drift that produced [`dev-orchestration#46`](https://github.com/alkem-io/dev-orchestration/pull/46), [`infrastructure-operations#2250`](https://github.com/alkem-io/infrastructure-operations/pull/2250), and [`server#6093`](https://github.com/alkem-io/server/pull/6093) — we shouldn't have to discover this kind of drift by hand again.

### Files synced

| Canonical file | Sync semantics |
|---|---|
| `synapse-modules/alkemio_room_control.py` | Verbatim — the file has no per-environment fields. |
| `registration.yaml` | Schema-only: `id`, `sender_localpart`, `receive_ephemeral`, `de.sorunome.msc2409.push_ephemeral`, `namespaces.*` are taken from canonical; each downstream's existing `url` / `as_token` / `hs_token` are preserved (those are dev secrets in server, `${MATRIX_*}` placeholders in the ops repos). |

### Pieces added

| Path | Purpose |
|---|---|
| `.scripts/sync-synapse-module.sh` | Bash. Idempotent. Syncs the `.py` module. File-mode for server, embedded-YAML mode for both ops repos. |
| `.scripts/sync-synapse-registration.py` | Python. Idempotent. Syncs `registration.yaml`. File-mode merge for server (preserves real tokens), printf-heredoc regeneration for both ops repos (preserves k8s URL + secret placeholders). |
| `.github/workflows/sync-synapse-module.yml` | Triggers on `push` to `develop` with path filter on both canonical files (plus `workflow_dispatch`). Matrix-fans across the three downstreams, runs both scripts per target, GPG-signs as the Alkemio Infrastructure Bot, force-pushes a fixed rolling branch `bot/sync-synapse-config`, opens or updates one PR per target. |
| `synapse-modules/README.md` | Adds a callout pointing readers at the sync mechanism. |
| `registration.yaml` | Adds a header comment naming the canonical role, and the missing `de.sorunome.msc2409.push_ephemeral: true` line (was the only one of four copies missing this — fixed as a precursor so the first sync run doesn't remove it from the downstreams). |

### Bot identity

Reuses the existing `Alkemio Infrastructure Bot <infrastructure@alkem.io>` identity that already drives [`server/.github/workflows/schema-baseline.yml`](https://github.com/alkem-io/server/blob/develop/.github/workflows/schema-baseline.yml). Required secrets on this repo (same names as on `server`):

- `ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN` — PAT with `contents:write` + `pull_requests:write` on `server`, `dev-orchestration`, `infrastructure-operations`
- `ALKEMIO_INFRASTRUCTURE_BOT_GPG_PRIVATE_KEY`
- `ALKEMIO_INFRASTRUCTURE_BOT_GPG_PASSPHRASE`
- `ALKEMIO_INFRASTRUCTURE_BOT_GPG_KEY_ID`

If those secrets don't yet exist on `matrix-adapter-go`, they need to be copied across before the workflow can run.

### PR strategy

Single rolling branch per target (`bot/sync-synapse-config`) — both files' changes land in the same PR, and subsequent canonical changes force-update the same PR. Max one open sync PR per downstream at any time.

### Local verification done

- Both scripts smoke-tested against all three downstreams: "no change" exit 0 across the board (downstreams already in sync from the precursor PRs).
- Destructive round-trip: temporarily mutated `registration.yaml` canonical (removed msc2409, added a fake namespace), ran both scripts, confirmed correct propagation: server preserved real `as_token`/`hs_token`, ops repos preserved k8s url + `${MATRIX_AS_TOKEN}`/`${MATRIX_HS_TOKEN}`, both saw the schema change. Reverted cleanly.
- Workflow YAML parses (`yaml.safe_load`).

## Test plan

- [ ] Confirm the four `ALKEMIO_INFRASTRUCTURE_BOT_*` secrets exist on `matrix-adapter-go`. The bot user has write + PR permissions on `server`, `dev-orchestration`, `infrastructure-operations`.
- [ ] Merge this PR. The workflow does NOT auto-trigger from this merge — the canonical files this commit modifies (`registration.yaml` adds one line) will trip the path filter, so expect three rolling PRs to appear shortly after merge, each carrying just the `de.sorunome.msc2409.push_ephemeral` re-add (no functional change since the downstreams already have the line, but the sync mechanism's first run will normalise everything).
- [ ] After those three rolling PRs are merged (or closed if no-op), run `workflow_dispatch` to confirm "no change" steady state.
- [ ] Make a no-op tweak to either canonical file (e.g. add a trailing comment), merge, observe the rolling PRs update in place rather than spawning new branches.
- [ ] Run `./.scripts/sync-synapse-module.sh <repo>` and `./.scripts/sync-synapse-registration.py <repo>` locally against each of the three downstreams to confirm idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow and scripts to keep the canonical Synapse module and registration synced to downstream repos, opening/ updating rolling-branch PRs when changes occur.

* **New Features**
  * Enabled push of ephemeral events via registration configuration (MSC2409-related setting).

* **Documentation**
  * Clarified README to mark the canonical source and advise against editing downstream copies directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/matrix-adapter-go/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
