### PR TITLE
chore: update CLAUDE.md link to agents-hq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # matrix-adapter-go Development Guidelines
 
 > **Workspace context.** This repo is part of the Alkemio polyrepo at
-> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> [alkem-io/agents-hq](https://github.com/alkem-io/agents-hq).
 > Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
 > working on a `feat/NNN-...` branch in this repo, the matching workspace
 > spec is the single source of truth.


### PR DESCRIPTION
Follow-up to the workspace repo rename (`alkemio-workspace` → `agents-hq`). Updates the CLAUDE.md workspace-context link to the new repo URL.

Doc-only. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)