### PR TITLE
chore(naming): promote matrix-adapter-go → matrix-adapter (workspace#002-promote-service-names)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,7 +61,7 @@ All Synapse Admin API calls MUST use `SynapseAdmin` (`internal/infrastructure/ma
 ## CI & Release Signals
 
 - **GitHub Actions**:
-  - `build-release-docker-hub.yml`: Builds and pushes the `alkemio/matrix-adapter-go` Docker image.
+  - `build-release-docker-hub.yml`: Builds and pushes the `alkemio/matrix-adapter` Docker image.
 - **Versioning**:
   - `VERSION` file or git tags for Go service.
   - `lib/package.json`: Library version (published to npm/GitHub Packages).

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,4 +1,4 @@
-# matrix-adapter-go Development Guidelines
+# matrix-adapter Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2025-11-28
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@
 ## CI & Release Signals
 
 - **GitHub Actions**:
-  - `build-release-docker-hub.yml`: Builds and pushes the `alkemio/matrix-adapter-go` Docker image.
+  - `build-release-docker-hub.yml`: Builds and pushes the `alkemio/matrix-adapter` Docker image.
 - **Versioning**:
   - `VERSION` file or git tags for Go service.
   - `lib/package.json`: Library version (published to npm/GitHub Packages).

--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build & push image
         run: |
-          IMAGE="${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter-go"
+          IMAGE="${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter"
           docker build -f Dockerfile . -t ${IMAGE}:${{ github.sha }} -t ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create image pull secret
         run: |
-          kubectl create secret docker-registry matrix-adapter-go-registry \
+          kubectl create secret docker-registry matrix-adapter-registry \
             --docker-server=${{ secrets.REGISTRY_LOGIN_SERVER }} \
             --docker-username=${{ secrets.REGISTRY_USERNAME }} \
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
@@ -53,9 +53,9 @@ jobs:
       - name: Attach image pull secret to deployment
         run: |
           kubectl patch deployment alkemio-matrix-adapter-deployment -p \
-            '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"matrix-adapter-go-registry"}]}}}}'
+            '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"matrix-adapter-registry"}]}}}}'
 
       - name: Update deployment image
         run: |
           kubectl set image deployment/alkemio-matrix-adapter-deployment \
-            alkemio-matrix-adapter=${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter-go:${{ github.sha }}
+            alkemio-matrix-adapter=${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter:${{ github.sha }}

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Build & push image
         run: |
-          IMAGE="${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter-go"
+          IMAGE="${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter"
           docker build -f Dockerfile . -t ${IMAGE}:${{ github.sha }} -t ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create image pull secret
         run: |
-          kubectl create secret docker-registry matrix-adapter-go-registry \
+          kubectl create secret docker-registry matrix-adapter-registry \
             --docker-server=${{ secrets.REGISTRY_LOGIN_SERVER }} \
             --docker-username=${{ secrets.REGISTRY_USERNAME }} \
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
@@ -52,9 +52,9 @@ jobs:
       - name: Attach image pull secret to deployment
         run: |
           kubectl patch deployment alkemio-matrix-adapter-deployment -p \
-            '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"matrix-adapter-go-registry"}]}}}}'
+            '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"matrix-adapter-registry"}]}}}}'
 
       - name: Update deployment image
         run: |
           kubectl set image deployment/alkemio-matrix-adapter-deployment \
-            alkemio-matrix-adapter=${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter-go:${{ github.sha }}
+            alkemio-matrix-adapter=${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter:${{ github.sha }}

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Build & push image
         run: |
-          IMAGE="${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter-go"
+          IMAGE="${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter"
           docker build -f Dockerfile . -t ${IMAGE}:${{ github.sha }} -t ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create image pull secret
         run: |
-          kubectl create secret docker-registry matrix-adapter-go-registry \
+          kubectl create secret docker-registry matrix-adapter-registry \
             --docker-server=${{ secrets.REGISTRY_LOGIN_SERVER }} \
             --docker-username=${{ secrets.REGISTRY_USERNAME }} \
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
@@ -52,9 +52,9 @@ jobs:
       - name: Attach image pull secret to deployment
         run: |
           kubectl patch deployment alkemio-matrix-adapter-deployment -p \
-            '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"matrix-adapter-go-registry"}]}}}}'
+            '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"matrix-adapter-registry"}]}}}}'
 
       - name: Update deployment image
         run: |
           kubectl set image deployment/alkemio-matrix-adapter-deployment \
-            alkemio-matrix-adapter=${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter-go:${{ github.sha }}
+            alkemio-matrix-adapter=${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter:${{ github.sha }}

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=alkemio/matrix-adapter-go
+          DOCKER_IMAGE=alkemio/matrix-adapter
           VERSION=noop
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -14,7 +14,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter-go
+          images: ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-matrix-adapter
           tags: |
             type=sha
             type=raw,value=latest

--- a/.github/workflows/sync-synapse-module.yml
+++ b/.github/workflows/sync-synapse-module.yml
@@ -23,7 +23,7 @@ name: Sync Synapse Config to Downstream Repos
 # re-running this workflow updates that PR's diff in-place rather than
 # opening new PRs. Both files' changes land in one PR when both are out of sync.
 #
-# Required secrets (configured in matrix-adapter-go):
+# Required secrets (configured in matrix-adapter):
 #
 #   ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN       PAT for the bot account with
 #                                               contents:write + pull_requests:write
@@ -77,7 +77,7 @@ jobs:
       TARGET_BASE: ${{ matrix.target.base }}
 
     steps:
-      - name: Checkout matrix-adapter-go (canonical)
+      - name: Checkout matrix-adapter (canonical)
         uses: actions/checkout@v4
         with:
           path: source
@@ -161,11 +161,11 @@ jobs:
 
           git checkout -B "$SYNC_BRANCH"
           git add -A
-          git commit -S -m "chore(synapse): sync canonical config from matrix-adapter-go@${SOURCE_SHA:0:7}
+          git commit -S -m "chore(synapse): sync canonical config from matrix-adapter@${SOURCE_SHA:0:7}
 
           Auto-synced from https://github.com/${{ github.repository }}/commit/${SOURCE_SHA}
 
-          Files synced from matrix-adapter-go:
+          Files synced from matrix-adapter:
             synapse-modules/alkemio_room_control.py
             registration.yaml (schema fields only; url / as_token / hs_token preserved)"
 
@@ -186,14 +186,14 @@ jobs:
             const base = process.env.TARGET_BASE;
             const sourceSha = process.env.SOURCE_SHA;
             const shortSha = sourceSha.slice(0, 7);
-            const title = `chore(synapse): sync canonical config from matrix-adapter-go`;
+            const title = `chore(synapse): sync canonical config from matrix-adapter`;
             const body = [
-              `Auto-synced from [matrix-adapter-go@${shortSha}](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sourceSha}).`,
+              `Auto-synced from [matrix-adapter@${shortSha}](https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sourceSha}).`,
               '',
-              'Two canonical Synapse-related files live in matrix-adapter-go and are propagated here automatically:',
+              'Two canonical Synapse-related files live in matrix-adapter and are propagated here automatically:',
               '',
-              '- [`synapse-modules/alkemio_room_control.py`](https://github.com/alkem-io/matrix-adapter-go/blob/develop/synapse-modules/alkemio_room_control.py) — synced verbatim.',
-              '- [`registration.yaml`](https://github.com/alkem-io/matrix-adapter-go/blob/develop/registration.yaml) — schema fields only; `url` / `as_token` / `hs_token` are preserved from this repo.',
+              '- [`synapse-modules/alkemio_room_control.py`](https://github.com/alkem-io/matrix-adapter/blob/develop/synapse-modules/alkemio_room_control.py) — synced verbatim.',
+              '- [`registration.yaml`](https://github.com/alkem-io/matrix-adapter/blob/develop/registration.yaml) — schema fields only; `url` / `as_token` / `hs_token` are preserved from this repo.',
               '',
               `Review and merge to roll the change forward to this repo's deployment. The branch (\`${branch}\`) is rolling — subsequent canonical changes will force-update this PR rather than open new ones.`,
             ].join('\n');

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/alkem-io/matrix-adapter-go
+        - github.com/alkem-io/matrix-adapter
 
 issues:
   max-issues-per-linter: 0

--- a/.scripts/sync-synapse-module.sh
+++ b/.scripts/sync-synapse-module.sh
@@ -2,7 +2,7 @@
 # Sync the canonical Synapse AlkemioRoomControl module into a downstream repo.
 #
 # Source of truth:
-#   matrix-adapter-go/synapse-modules/alkemio_room_control.py
+#   matrix-adapter/synapse-modules/alkemio_room_control.py
 #
 # Downstream layouts handled:
 #

--- a/.scripts/sync-synapse-registration.py
+++ b/.scripts/sync-synapse-registration.py
@@ -3,7 +3,7 @@
 Sync the canonical Synapse AppService registration shape into a downstream repo.
 
 Source of truth:
-  matrix-adapter-go/registration.yaml
+  matrix-adapter/registration.yaml
 
 Downstream layouts:
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -57,7 +57,7 @@ Tests exist to defend adapter contract invariants and observable behaviors that 
 
 ### 7. Go Service as Source of Truth
 
-The `pkg/dto` package in the Go service defines the canonical command payloads, event types, and DTO structures. The shared TypeScript library (`@alkem-io/matrix-adapter-go-lib`) MUST be generated from these Go definitions (e.g., using `cmd/gen-events` or `tygo`). Manual edits to the TypeScript definitions are forbidden.
+The `pkg/dto` package in the Go service defines the canonical command payloads, event types, and DTO structures. The shared TypeScript library (`@alkem-io/matrix-adapter-lib`) MUST be generated from these Go definitions (e.g., using `cmd/gen-events` or `tygo`). Manual edits to the TypeScript definitions are forbidden.
 
 **Rationale**: Centralizing the source of truth in the Go service ensures that the implementation and the contract remain in sync. Automated generation prevents drift between the producer (Go) and consumer (Node.js/TypeScript).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# matrix-adapter-go Development Guidelines
+# matrix-adapter Development Guidelines
 
 > **Workspace context.** This repo is part of the Alkemio polyrepo at
 > [alkem-io/agents-hq](https://github.com/alkem-io/agents-hq).

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ deps:
 .PHONY: docker-build
 docker-build:
 	@echo "Building Docker image..."
-	docker build -t alkemio/matrix-adapter-go .
+	docker build -t alkemio/matrix-adapter .
 
 # Help
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A high-performance, stateless Matrix Adapter service written in Go, implementing the Alkemio Matrix Adapter specification.
 
-[![Build Status](https://app.travis-ci.com/alkem-io/matrix-adapter-go.svg?branch=develop)](https://app.travis-ci.com/alkem-io/matrix-adapter-go.svg?branch=develop)
-[![Coverage Status](https://coveralls.io/repos/github/alkem-io/matrix-adapter-go/badge.svg?branch=develop)](https://coveralls.io/github/alkem-io/matrix-adapter-go?branch=develop)
-[![Deploy to DockerHub](https://github.com/alkem-io/matrix-adapter-go/actions/workflows/build-release-docker-hub.yml/badge.svg)](https://github.com/alkem-io/matrix-adapter-go/actions/workflows/build-release-docker-hub.yml)
+[![Build Status](https://app.travis-ci.com/alkem-io/matrix-adapter.svg?branch=develop)](https://app.travis-ci.com/alkem-io/matrix-adapter.svg?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/alkem-io/matrix-adapter/badge.svg?branch=develop)](https://coveralls.io/github/alkem-io/matrix-adapter?branch=develop)
+[![Deploy to DockerHub](https://github.com/alkem-io/matrix-adapter/actions/workflows/build-release-docker-hub.yml/badge.svg)](https://github.com/alkem-io/matrix-adapter/actions/workflows/build-release-docker-hub.yml)
 
 
 This repository contains two core elements:
@@ -124,7 +124,7 @@ The shared TypeScript library (`lib/`) is automatically published via GitHub Act
 
 4. **Install preview** (development/testing):
    ```bash
-   npm install https://pkg.pr.new/alkem-io/matrix-adapter-go/@alkemio/matrix-adapter-lib@{commit-sha}
+   npm install https://pkg.pr.new/alkem-io/matrix-adapter/@alkemio/matrix-adapter-lib@{commit-sha}
    ```
 
 ### Authentication

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/app"
-	"github.com/alkem-io/matrix-adapter-go/internal/config"
+	"github.com/alkem-io/matrix-adapter/internal/app"
+	"github.com/alkem-io/matrix-adapter/internal/config"
 )
 
 func main() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 'host.docker.internal:host-gateway'
     container_name: alkemio_dev_matrix_adapter
     hostname: matrix-adapter
-    image: alkemio/matrix-adapter-go:v0.8.0
+    image: alkemio/matrix-adapter:v0.8.0
     platform: linux/amd64
     environment:
       - RABBITMQ_HOST

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alkem-io/matrix-adapter-go
+module github.com/alkem-io/matrix-adapter
 
 go 1.25.1
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/config"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	httpinfra "github.com/alkem-io/matrix-adapter-go/internal/infrastructure/http"
-	"github.com/alkem-io/matrix-adapter-go/internal/infrastructure/logger"
-	"github.com/alkem-io/matrix-adapter-go/internal/infrastructure/matrix"
-	"github.com/alkem-io/matrix-adapter-go/internal/infrastructure/queue"
+	"github.com/alkem-io/matrix-adapter/internal/config"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	httpinfra "github.com/alkem-io/matrix-adapter/internal/infrastructure/http"
+	"github.com/alkem-io/matrix-adapter/internal/infrastructure/logger"
+	"github.com/alkem-io/matrix-adapter/internal/infrastructure/matrix"
+	"github.com/alkem-io/matrix-adapter/internal/infrastructure/queue"
 )
 
 // App represents the Matrix Adapter application and holds references to all its components.

--- a/internal/core/ports/matrix.go
+++ b/internal/core/ports/matrix.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
 )
 
 // MatrixPort defines the interface for Matrix operations.

--- a/internal/core/ports/services.go
+++ b/internal/core/ports/services.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
 )
 
 // ReadReceiptServicePort defines the interface for read receipt service operations.

--- a/internal/core/service/actor_read_receipt_test.go
+++ b/internal/core/service/actor_read_receipt_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/core/service/actor_service.go
+++ b/internal/core/service/actor_service.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // ActorService handles operations related to actor profile synchronization.

--- a/internal/core/service/dm_service.go
+++ b/internal/core/service/dm_service.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // DMService handles DM request events from Synapse and publishes them to the queue.

--- a/internal/core/service/dm_service_test.go
+++ b/internal/core/service/dm_service_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 func TestDMService_PublishDMRequest_Success(t *testing.T) {

--- a/internal/core/service/event_service.go
+++ b/internal/core/service/event_service.go
@@ -4,10 +4,10 @@ package service
 import (
 	"fmt"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/config"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/config"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // EventService handles incoming Matrix events and publishes them to the queue.

--- a/internal/core/service/event_service_test.go
+++ b/internal/core/service/event_service_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // newEventService creates an EventService with the given mock queue for testing.

--- a/internal/core/service/read_receipt_service.go
+++ b/internal/core/service/read_receipt_service.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // ReadReceiptService handles read receipt operations.

--- a/internal/core/service/room_check_service.go
+++ b/internal/core/service/room_check_service.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 const roomCheckTimeout = 3 * time.Second

--- a/internal/core/service/room_check_service_test.go
+++ b/internal/core/service/room_check_service_test.go
@@ -8,9 +8,9 @@ import (
 
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 const (

--- a/internal/core/service/room_service.go
+++ b/internal/core/service/room_service.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // RoomService handles operations related to Matrix rooms.

--- a/internal/core/service/room_service_extended_test.go
+++ b/internal/core/service/room_service_extended_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
 )
 
 // ============================================================================

--- a/internal/core/service/room_service_test.go
+++ b/internal/core/service/room_service_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
 )
 
 // mockMatrixPort is a minimal test double for MatrixPort.

--- a/internal/core/service/space_service.go
+++ b/internal/core/service/space_service.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // SpaceService handles operations related to Matrix Spaces.

--- a/internal/core/service/space_service_test.go
+++ b/internal/core/service/space_service_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
 )
 
 // ============================================================================

--- a/internal/infrastructure/http/check_room_handler.go
+++ b/internal/infrastructure/http/check_room_handler.go
@@ -9,10 +9,10 @@ import (
 
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // CheckRoomHandler handles synchronous room creation check requests from the Synapse module.

--- a/internal/infrastructure/http/check_room_handler_test.go
+++ b/internal/infrastructure/http/check_room_handler_test.go
@@ -8,10 +8,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 const (

--- a/internal/infrastructure/http/dm_webhook.go
+++ b/internal/infrastructure/http/dm_webhook.go
@@ -9,10 +9,10 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // DMWebhookHandler handles incoming DM request webhooks from Synapse.

--- a/internal/infrastructure/http/dm_webhook_test.go
+++ b/internal/infrastructure/http/dm_webhook_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 const (

--- a/internal/infrastructure/http/health.go
+++ b/internal/infrastructure/http/health.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // HTTPServer provides the main HTTP server for health checks and webhooks.

--- a/internal/infrastructure/http/health_test.go
+++ b/internal/infrastructure/http/health_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 type healthMockLogger struct{}

--- a/internal/infrastructure/logger/zap.go
+++ b/internal/infrastructure/logger/zap.go
@@ -5,7 +5,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // ZapLogger is a Logger implementation using Uber's zap library.

--- a/internal/infrastructure/logger/zap_test.go
+++ b/internal/infrastructure/logger/zap_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 func TestNewZapLogger_Debug(t *testing.T) {

--- a/internal/infrastructure/matrix/listener.go
+++ b/internal/infrastructure/matrix/listener.go
@@ -11,7 +11,7 @@ import (
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
 )
 
 // reconciling tracks rooms currently undergoing reconciliation to prevent concurrent attempts.

--- a/internal/infrastructure/matrix/mautrix.go
+++ b/internal/infrastructure/matrix/mautrix.go
@@ -23,10 +23,10 @@ import (
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/config"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/config"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // MautrixAdapter implements the MatrixPort interface using the mautrix-go library.

--- a/internal/infrastructure/matrix/mautrix_admin_test.go
+++ b/internal/infrastructure/matrix/mautrix_admin_test.go
@@ -12,8 +12,8 @@ import (
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // ============================================================================

--- a/internal/infrastructure/matrix/mautrix_helpers_test.go
+++ b/internal/infrastructure/matrix/mautrix_helpers_test.go
@@ -12,8 +12,8 @@ import (
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/testutil"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/testutil"
 )
 
 // newTestAdapter creates a minimal MautrixAdapter with only the idMapper set,

--- a/internal/infrastructure/matrix/mautrix_intent_test.go
+++ b/internal/infrastructure/matrix/mautrix_intent_test.go
@@ -14,7 +14,7 @@ import (
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
 )
 
 // ============================================================================

--- a/internal/infrastructure/queue/errors.go
+++ b/internal/infrastructure/queue/errors.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // ============================================================================

--- a/internal/infrastructure/queue/errors_test.go
+++ b/internal/infrastructure/queue/errors_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 func TestMapServiceError(t *testing.T) {

--- a/internal/infrastructure/queue/handler_actor.go
+++ b/internal/infrastructure/queue/handler_actor.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // ActorHandler handles queue messages related to actor operations.

--- a/internal/infrastructure/queue/handler_other_test.go
+++ b/internal/infrastructure/queue/handler_other_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // ============================================================================

--- a/internal/infrastructure/queue/handler_read_receipt.go
+++ b/internal/infrastructure/queue/handler_read_receipt.go
@@ -6,9 +6,9 @@ import (
 
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // ReadReceiptHandler handles queue messages related to read receipt operations.

--- a/internal/infrastructure/queue/handler_room.go
+++ b/internal/infrastructure/queue/handler_room.go
@@ -8,10 +8,10 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // RoomHandler handles queue messages related to room operations.

--- a/internal/infrastructure/queue/handler_room_test.go
+++ b/internal/infrastructure/queue/handler_room_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // ============================================================================

--- a/internal/infrastructure/queue/handler_space.go
+++ b/internal/infrastructure/queue/handler_space.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/service"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/service"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // SpaceHandler handles queue messages related to space operations.

--- a/internal/infrastructure/queue/resolver.go
+++ b/internal/infrastructure/queue/resolver.go
@@ -5,9 +5,9 @@ import (
 
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // AliasResolver resolves Alkemio IDs to Matrix room IDs.

--- a/internal/infrastructure/queue/router.go
+++ b/internal/infrastructure/queue/router.go
@@ -3,7 +3,7 @@ package queue
 import (
 	"context"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // RegisterRoutes registers all queue subscribers to their respective topics.

--- a/internal/infrastructure/queue/test_helpers_test.go
+++ b/internal/infrastructure/queue/test_helpers_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/domain"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/core/domain"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // ============================================================================

--- a/internal/infrastructure/queue/topics.go
+++ b/internal/infrastructure/queue/topics.go
@@ -1,7 +1,7 @@
 // Package queue provides RabbitMQ message queue infrastructure.
 package queue
 
-import "github.com/alkem-io/matrix-adapter-go/pkg/dto"
+import "github.com/alkem-io/matrix-adapter/pkg/dto"
 
 // Topic aliases for internal use - imported from dto (single source of truth).
 const (

--- a/internal/infrastructure/queue/watermill.go
+++ b/internal/infrastructure/queue/watermill.go
@@ -12,9 +12,9 @@ import (
 	"github.com/pkg/errors"
 	stdAmqp "github.com/rabbitmq/amqp091-go"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/config"
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
-	"github.com/alkem-io/matrix-adapter-go/pkg/dto"
+	"github.com/alkem-io/matrix-adapter/internal/config"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/pkg/dto"
 )
 
 // Metadata keys for AMQP native properties

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/alkem-io/matrix-adapter-go/internal/core/ports"
+	"github.com/alkem-io/matrix-adapter/internal/core/ports"
 )
 
 // MockQueuePort is a test double for ports.QueuePort that records the last published topic and payload.

--- a/lib/package.json
+++ b/lib/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alkem-io/matrix-adapter-go.git"
+    "url": "git+https://github.com/alkem-io/matrix-adapter.git"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/specs/001-ci-lib-publish/plan.md
+++ b/specs/001-ci-lib-publish/plan.md
@@ -1,7 +1,7 @@
 # Plan: CI/CD for Shared Library Publishing
 
 ## Goal
-Implement a GitHub Actions workflow to automatically publish the `@alkem-io/matrix-adapter-go-lib` package to GitHub Packages on tags and relevant PRs.
+Implement a GitHub Actions workflow to automatically publish the `@alkem-io/matrix-adapter-lib` package to GitHub Packages on tags and relevant PRs.
 
 ## Phases
 

--- a/specs/002-rmq-error-handling/contracts/rmq-response.md
+++ b/specs/002-rmq-error-handling/contracts/rmq-response.md
@@ -36,7 +36,7 @@ All handlers always ACK after execution. Infrastructure failures are handled by 
 ## TypeScript Usage
 
 ```typescript
-import { BaseResponse, ErrorCodeNotFound } from '@alkem-io/matrix-adapter-go-lib';
+import { BaseResponse, ErrorCodeNotFound } from '@alkem-io/matrix-adapter-lib';
 
 if (!response.success && response.error?.code === ErrorCodeNotFound) {
   throw new NotFoundException(response.error.message);

--- a/specs/002-rmq-error-handling/quickstart.md
+++ b/specs/002-rmq-error-handling/quickstart.md
@@ -34,7 +34,7 @@ func (h *ActorHandler) HandleRegister(payload []byte) (interface{}, error) {
 ## Consumer Usage (TypeScript)
 
 ```typescript
-import { BaseResponse, ErrorCodeNotFound } from '@alkem-io/matrix-adapter-go-lib';
+import { BaseResponse, ErrorCodeNotFound } from '@alkem-io/matrix-adapter-lib';
 
 if (!response.success) {
   switch (response.error?.code) {

--- a/specs/002-rmq-error-handling/spec.md
+++ b/specs/002-rmq-error-handling/spec.md
@@ -51,7 +51,7 @@ All error responses include:
 ## Consumer Usage
 
 ```typescript
-import { BaseResponse, ErrorCodeNotFound } from '@alkem-io/matrix-adapter-go-lib';
+import { BaseResponse, ErrorCodeNotFound } from '@alkem-io/matrix-adapter-lib';
 
 if (!response.success) {
   if (response.error?.code === ErrorCodeNotFound) {

--- a/specs/004-rmq-protocol-update/quickstart.md
+++ b/specs/004-rmq-protocol-update/quickstart.md
@@ -123,7 +123,7 @@ if (!response.success) {
 Install the generated library:
 
 ```bash
-npm install @alkem-io/matrix-adapter-go-lib
+npm install @alkem-io/matrix-adapter-lib
 ```
 
 Import types:
@@ -136,7 +136,7 @@ import {
   SendMessageResponse,
   ErrorCode,
   // ... etc
-} from '@alkem-io/matrix-adapter-go-lib';
+} from '@alkem-io/matrix-adapter-lib';
 ```
 
 ---

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -1,5 +1,5 @@
 packages:
-  - path: "github.com/alkem-io/matrix-adapter-go/pkg/dto"
+  - path: "github.com/alkem-io/matrix-adapter/pkg/dto"
     output_path: "lib/src/dto/generated.ts"
     fallback_type: "any"
     type_mappings:


### PR DESCRIPTION
## Summary

In-repo code/CI rename promoting the Go service formerly `matrix-adapter-go` to its canonical name `matrix-adapter` — the `matrix-adapter` slice of workspace feature `workspace#002-promote-service-names`.

The GitHub repo was already renamed `matrix-adapter-go` → `matrix-adapter` and the remote already points at the canonical URL. This PR completes the in-repo identifiers per the canonical-names boundary contract (`specs/002-promote-service-names/contracts/canonical-names.md`).

### What changed (canonical transform: drop `-go`, change nothing else)
- **`go.mod`** — module path `github.com/alkem-io/matrix-adapter-go` → `github.com/alkem-io/matrix-adapter`.
- **45 `.go` files** — internal import paths updated to the canonical module path.
- **`tygo.yaml`** — DTO source package `…/matrix-adapter-go/pkg/dto` → `…/matrix-adapter/pkg/dto`.
- **CI image names** — Scaleway `alkemio-matrix-adapter-go` → `alkemio-matrix-adapter` (`container-build.yml` + dev/test/sandbox k8s deploy workflows); Docker Hub `alkemio/matrix-adapter-go` → `alkemio/matrix-adapter` (`build-release-docker-hub.yml`).
- **Registry pull-secret** — `matrix-adapter-go-registry` → `matrix-adapter-registry` (producer side, dev/test/sandbox deploy workflows).
- **Self-references** — `Makefile`, `docker-compose.yml` (image tag only), `README.md`, `.golangci.yml`, repo-name references in `sync-synapse-module.yml` and the sync scripts, onboarding docs (`CLAUDE.md`, `.claude/CLAUDE.md`, copilot instructions, constitution), `lib/package.json` `repository.url`, and historical in-repo spec docs.
- `build-push-ghcr-pr.yml` uses `ghcr.io/${{ github.repository }}` and auto-follows the repo rename — no edit needed.

### Frozen — intentionally NOT changed (boundary contract §3)
Runtime service-discovery identifiers are load-bearing and left untouched: in-cluster hostname `matrix-adapter`, port `8280`, Synapse AppService `id: alkemio-matrix-adapter`, k8s Service/Deployment/container names `alkemio-matrix-adapter*`, labels. The npm lib `@alkemio/matrix-adapter-lib` (already canonical) is unchanged.

### Gates
- `go build ./...` passes.
- `grep -rIn 'matrix-adapter-go' . --exclude-dir=.git` returns no output.
- Diff is a clean `-go` drop (every removed line contained `matrix-adapter-go`; no added line reintroduces it); no frozen §3 identifier appears in the diff.

⚠️ Canonical release (v0.8.17) is NOT cut here — it must be published before any consumer manifest repin merges (additive-then-retire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image naming from `alkemio/matrix-adapter-go` to `alkemio/matrix-adapter` across build and deployment workflows.
  * Renamed NPM package from `@alkem-io/matrix-adapter-go-lib` to `@alkem-io/matrix-adapter-lib`.
  * Updated module paths and import references throughout the codebase to reflect repository structure changes.
  * Aligned documentation and CI/CD configurations to reference the updated naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alkem-io/matrix-adapter/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->