### PR TITLE
ci: unify image workflows — native multi-arch + PR image footer

### DIFF
--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -1,51 +1,195 @@
+# Builds the multi-arch (linux/amd64 + linux/arm64) PR image and pushes it to
+# GHCR, then reports the image to grab in a footer of the PR description.
+# Same native-runner digest-merge pattern as the release workflow (org-unified,
+# first validated in alkem-io/notifications#525) — no QEMU.
+#
+# Tags: ghcr.io/<repo>:pr-<N> always points at the PR's latest build (grab
+# this one to test the current state); ghcr.io/<repo>:pr-<N>-<sha> pins each
+# build immutably.
+#
+# Fork PRs: GITHUB_TOKEN is read-only, so the build jobs only validate the
+# image builds on both arches — nothing is pushed and no footer is written.
 name: Build & Push Container (PR)
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Only the newest commit's image matters; abandon superseded builds.
+concurrency:
+  group: pr-image-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            pair: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            pair: linux-arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.1.0
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          # Tags are applied at the merge job; this step only supplies OCI labels.
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Login to GitHub Container Registry
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7.2.0
         with:
-          images: ghcr.io/${{ github.repository }}
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Untagged push; the merge job assembles the manifest list from
+          # digests. Fork PRs build without pushing (read-only token).
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          # Ephemeral GHA cache, one scope per arch
+          cache-from: type=gha,scope=${{ matrix.pair }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.pair }}
+
+      - name: Export digest
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: digests-${{ matrix.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write    # PR-description image footer
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.1.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=ref,event=pr
             type=sha,prefix=pr-${{ github.event.number }}-
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      - name: Download digests
+        uses: actions/download-artifact@v8.0.1
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Verify digest set
+        # Never publish a single-arch index under the pr-N tags from a
+        # partial digest set.
+        run: |
+          count=$(ls -1 "${{ runner.temp }}/digests" 2>/dev/null | wc -l)
+          if [ "$count" -ne 2 ]; then
+            echo "::error::expected 2 digest files (amd64 + arm64), found ${count}."
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          declare -a args
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          while IFS= read -r ann; do
+            args+=(--annotation "$ann")
+          done < <(jq -cr '.annotations[]?' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create "${args[@]}" \
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
+
+      - name: Report image in PR description footer
+        # Upserts a marker-delimited footer at the end of the PR body so
+        # anyone looking at the PR sees which image to grab to test its
+        # current state. The floating pr-N tag stays true across commits;
+        # only the pinned tag/digest line changes. Body edits generate no
+        # notifications, so this never spams the PR.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          floating="${REGISTRY_IMAGE}:pr-${PR_NUMBER}"
+          pinned=$(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON" | grep ":pr-${PR_NUMBER}-" | head -1)
+          digest=$(docker buildx imagetools inspect "$floating" --format '{{json .Manifest}}' | jq -r .digest)
+
+          start='<!-- pr-image-report:start -->'
+          end='<!-- pr-image-report:end -->'
+          footer="$start
+          ---
+          ### 📦 PR image — test the current state of this PR
+
+          \`\`\`bash
+          docker pull $floating
+          \`\`\`
+
+          Current build: \`$pinned\` · \`linux/amd64\` + \`linux/arm64\` · index digest \`$digest\`
+          $end"
+
+          gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.body // ""' > /tmp/body.md
+          perl -0777 -pe "s/\n*\Q$start\E.*?\Q$end\E//s" /tmp/body.md > /tmp/body-stripped.md
+          printf '%s\n\n%s\n' "$(cat /tmp/body-stripped.md)" "$footer" > /tmp/body-new.md
+          gh api -X PATCH "repos/${{ github.repository }}/pulls/${PR_NUMBER}" -F body=@/tmp/body-new.md > /dev/null
+
+          {
+            echo "### 📦 PR image"
+            echo '```bash'
+            echo "docker pull $floating"
+            echo '```'
+            echo "Pinned: \`$pinned\` · digest \`$digest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -1,75 +1,176 @@
+# Builds and publishes the multi-arch (linux/amd64 + linux/arm64) Docker image
+# to Docker Hub. Each architecture builds NATIVELY on its own runner (no QEMU),
+# pushes by digest, and a final job stitches the digests into one manifest
+# list. Org-unified pattern (first validated in alkem-io/notifications#525).
+# Triggered only on GitHub releases, so push/login operations are always safe.
 name: Deploy to DockerHub
 
 on:
   release:
-    types: [published]
+    # `released` additionally covers a pre-release later promoted to a full
+    # release (promotion fires no `published` event, so latest/vMAJOR would
+    # otherwise never be applied). A normal stable publish fires BOTH types;
+    # the two runs serialize via the concurrency group and are idempotent —
+    # a few duplicate runner-minutes buy the promotion path.
+    types: [published, released]
+
+# Serialize whole runs against each other (the per-arch builds inside one run
+# still parallelize): two releases published minutes apart must apply their
+# floating tags (latest, vMAJOR, vMAJOR.MINOR) in publish order, or the older
+# release's slower run could re-point them backward.
+concurrency:
+  group: dockerhub-release
+  cancel-in-progress: false
+
+env:
+  REGISTRY_IMAGE: alkemio/${{ github.event.repository.name }}
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            pair: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            pair: linux-arm64
+    runs-on: ${{ matrix.runner }}
+    # A hung build must not hold the release (and the concurrency queue)
+    # for the 6h default.
+    timeout-minutes: 30
+    permissions:
+      contents: read    # Required for actions/checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=alkemio/matrix-adapter
-          VERSION=noop
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            VERSION=nightly
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            MINOR=${VERSION%.*}
-            MAJOR=${MINOR%.*}
-            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
-          fi
-          {
-            echo "version=${VERSION}"
-            echo "tags=${TAGS}"
-            echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.1.0
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          # Tags are applied at the merge job; this step only supplies OCI labels.
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v7
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7.2.0
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Untagged push; the merge job assembles the manifest list from digests.
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Registry cache, one ref per arch so the builders don't evict each other
+          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.pair }}
+          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.pair }},mode=max
+          # SLSA provenance attestation for supply chain security
+          provenance: mode=max
+          # SBOM: machine-readable inventory of all components in the image —
+          # CVE scanning, compliance audits, supply chain transparency.
+          sbom: true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: digests-${{ matrix.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          # Recovery window: a failed merge can be re-run from these digests
+          # without rebuilding for up to a week.
+          retention-days: 7
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.1.0
+        env:
+          # Also emit OCI annotations targeting the manifest list (index),
+          # applied by imagetools create below — labels on the per-arch image
+          # configs alone are invisible to tooling reading the tagged index.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            # Only tag as 'latest' for stable releases, not prereleases.
+            # The event_name guard matters: on non-release events
+            # `github.event.release.prerelease == false` coerces null==false -> true.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+            type=sha,prefix=sha-
+
+      - name: Download digests
+        uses: actions/download-artifact@v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Verify digest set
+        # Publishing from a partial set would silently ship a single-arch
+        # index under all release tags ('imagetools create' happily performs
+        # a one-source carbon copy). Also turns the expired-artifacts case
+        # (>7d-late re-run) into a clear error instead of a cryptic one.
+        run: |
+          count=$(ls -1 "${{ runner.temp }}/digests" 2>/dev/null | wc -l)
+          if [ "$count" -ne 2 ]; then
+            echo "::error::expected 2 digest files (amd64 + arm64), found ${count}. If the artifacts expired (retention 7d), re-run the whole workflow, not just this job."
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest and push
+        working-directory: ${{ runner.temp }}/digests
+        # Tag/annotation args are built as a bash array: annotation values
+        # (e.g. image description) contain spaces, so the naive
+        # jq-into-word-splitting from the docs example would mangle them.
+        run: |
+          declare -a args
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          while IFS= read -r ann; do
+            args+=(--annotation "$ann")
+          done < <(jq -cr '.annotations[]?' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create "${args[@]}" \
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
+
+      - name: Inspect manifest
+        # Inspect the primary tag actually pushed (meta.outputs.version can be
+        # empty for tags matching no semver pattern, which would fail this step
+        # red after a successful publish).
+        run: docker buildx imagetools inspect "$(jq -cr '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")"


### PR DESCRIPTION
Rolls out the org-unified container-image workflows (production-validated in alkem-io/notifications#525) to matrix-adapter. Both files are verbatim copies of the org templates — fully repo-generic, no repo-specific edits needed (`context: .`, `file: ./Dockerfile`, Docker Hub `alkemio/matrix-adapter`, GHCR `ghcr.io/alkem-io/matrix-adapter` all hold here).

## What changes

### Native runners replace QEMU
Both workflows build each architecture **natively** — `ubuntu-latest` for `linux/amd64`, `ubuntu-24.04-arm` for `linux/arm64` — pushing by digest, with a merge job stitching the digests into one manifest list. No more QEMU-emulated arm64 builds.

### Release workflow (`build-release-docker-hub.yml`) hardening
- **Digest-arity guard** — the merge job refuses to publish unless exactly 2 digest files (amd64 + arm64) are present, so a partial build can never silently ship a single-arch index under the release tags.
- **`released` trigger** added alongside `published` — covers a pre-release later promoted to a full release (promotion fires no `published` event, so `latest`/`vMAJOR` would otherwise never be applied). The duplicate runs on a normal stable publish serialize and are idempotent.
- **Concurrency serialization** (`dockerhub-release`, no cancel-in-progress) — two releases published minutes apart apply their floating tags (`latest`, `vMAJOR`, `vMAJOR.MINOR`) in publish order.
- **Timeouts** — 30 min per build leg, 15 min merge; a hung build can't hold the release queue for the 6h default.
- **7-day digest-artifact retention** — a failed merge can be re-run from the stored digests without rebuilding, for up to a week.
- **Index-level OCI annotations** — annotations are applied to the manifest list itself (via `DOCKER_METADATA_ANNOTATIONS_LEVELS: index` + `imagetools create --annotation`); labels on the per-arch image configs alone are invisible to tooling reading the tagged index.
- Plus SLSA provenance (`mode=max`), SBOM generation, and per-arch registry build cache (`buildcache-linux-amd64` / `buildcache-linux-arm64`).

### PR workflow (`build-push-ghcr-pr.yml`)
- Same native digest-merge pattern; per-arch GHA cache scopes.
- **PR-description footer reporting** — the merge job upserts a marker-delimited footer into the PR description with the image to pull: the floating `ghcr.io/alkem-io/matrix-adapter:pr-<N>` (always the PR's latest build) and the pinned `pr-<N>-<sha>` + index digest. Body edits generate no notifications, so it never spams the PR. (This very PR self-validates the mechanism — see its footer.)
- **Fork-PR build-only behavior** — `GITHUB_TOKEN` is read-only for fork PRs, so the build legs only validate the image builds on both arches; nothing is pushed and no footer is written.
- Concurrency per PR with cancel-in-progress: superseded commits abandon their builds.

## Notes
- Unlike notifications, this repo's previous release workflow used **no** registry build cache, so there is no orphaned `:buildcache` tag on Docker Hub to clean up (verified: tag does not exist).
- Other workflows (`ci.yml`, `container-build.yml`, `publish-lib.yml`, `sync-synapse-module.yml`, deploy workflows) are untouched, as are `lib/` (TypeScript package) and the generated `openapi.yaml`.

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/matrix-adapter:pr-59
```

Current build: `ghcr.io/alkem-io/matrix-adapter:pr-59-b2c9779` · `linux/amd64` + `linux/arm64` · index digest `sha256:0c56f02660f5959d664e0b5a5640562b60bc4e236b35592b446587e5bd1a4ecb`
<!-- pr-image-report:end -->
