### PR TITLE
chore: add standardized k8s manifests (dev/test deployments + service)

### DIFF
--- a/manifests/25-matrix-adapter-deployment-dev.yaml
+++ b/manifests/25-matrix-adapter-deployment-dev.yaml
@@ -1,0 +1,148 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  namespace: default
+  name: alkemio-matrix-adapter-deployment
+  labels:
+    app: alkemio-matrix-adapter
+    k8s-app: alkemio-matrix-adapter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alkemio-matrix-adapter
+  template:
+    metadata:
+      labels:
+        app: alkemio-matrix-adapter
+    spec:
+      containers:
+        - name: alkemio-matrix-adapter
+          image: rg.nl-ams.scw.cloud/alkemio/alkemio-matrix-adapter:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8280
+          env:
+            # RabbitMQ configuration
+            - name: RABBITMQ_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: host
+            - name: RABBITMQ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: username
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: password
+            # Synapse configuration
+            - name: SYNAPSE_HOMESERVER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: SYNAPSE_HOMESERVER_NAME
+            - name: SYNAPSE_SERVER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: SYNAPSE_SERVER_URL
+            - name: SYNAPSE_SERVER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: SYNAPSE_HOMESERVER_NAME
+            # Matrix tokens
+            - name: MATRIX_AS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-secrets
+                  key: MATRIX_AS_TOKEN
+            - name: MATRIX_HS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-secrets
+                  key: MATRIX_HS_TOKEN
+            # Logging configuration
+            - name: LOGGING_CONSOLE_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: LOGGING_CONSOLE_ENABLED
+            - name: LOGGING_LEVEL_CONSOLE
+              value: "debug"
+            # Database configuration
+            - name: DATABASE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: DATABASE_HOST
+            - name: DATABASE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: DATABASE_PORT
+            - name: DATABASE_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: POSTGRES_USER
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: POSTGRES_PASSWORD
+            - name: ACTOR_ID_MAPPER_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: ACTOR_ID_MAPPER_ENABLED
+            - name: DATABASE_NAME
+              value: "alkemio"
+          envFrom:
+            - secretRef:
+                name: alkemio-secrets
+            - configMapRef:
+                name: alkemio-config
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8280
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8280
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 5
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: alkemio-rabbitmq-cluster
+                topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-server
+                topologyKey: kubernetes.io/hostname

--- a/manifests/26-matrix-adapter-deployment-test.yaml
+++ b/manifests/26-matrix-adapter-deployment-test.yaml
@@ -1,0 +1,147 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  namespace: default
+  name: alkemio-matrix-adapter-deployment
+  labels:
+    app: alkemio-matrix-adapter
+    k8s-app: alkemio-matrix-adapter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alkemio-matrix-adapter
+  template:
+    metadata:
+      labels:
+        app: alkemio-matrix-adapter
+    spec:
+      containers:
+        - name: alkemio-matrix-adapter
+          image: rg.nl-ams.scw.cloud/alkemio/alkemio-matrix-adapter:latest
+          ports:
+            - name: http
+              containerPort: 8280
+          env:
+            # RabbitMQ configuration
+            - name: RABBITMQ_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: host
+            - name: RABBITMQ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: username
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-rabbitmq-cluster-default-user
+                  key: password
+            # Synapse configuration
+            - name: SYNAPSE_HOMESERVER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: SYNAPSE_HOMESERVER_NAME
+            - name: SYNAPSE_SERVER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: SYNAPSE_SERVER_URL
+            - name: SYNAPSE_SERVER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: SYNAPSE_HOMESERVER_NAME
+            # Matrix tokens
+            - name: MATRIX_AS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-secrets
+                  key: MATRIX_AS_TOKEN
+            - name: MATRIX_HS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: alkemio-secrets
+                  key: MATRIX_HS_TOKEN
+            # Logging configuration
+            - name: LOGGING_CONSOLE_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: LOGGING_CONSOLE_ENABLED
+            - name: LOGGING_LEVEL_CONSOLE
+              value: "debug"
+            # Database configuration
+            - name: DATABASE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: DATABASE_HOST
+            - name: DATABASE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: DATABASE_PORT
+            - name: DATABASE_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: POSTGRES_USER
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: POSTGRES_PASSWORD
+            - name: ACTOR_ID_MAPPER_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: alkemio-config
+                  key: ACTOR_ID_MAPPER_ENABLED
+            - name: DATABASE_NAME
+              value: "alkemio"
+          envFrom:
+            - secretRef:
+                name: alkemio-secrets
+            - configMapRef:
+                name: alkemio-config
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8280
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8280
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 5
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: alkemio-rabbitmq-cluster
+                topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: alkemio-server
+                topologyKey: kubernetes.io/hostname

--- a/manifests/30-matrix-adapter-service.yaml
+++ b/manifests/30-matrix-adapter-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alkemio-matrix-adapter-service
+  namespace: default
+  labels:
+    app: alkemio-matrix-adapter
+spec:
+  selector:
+    app: alkemio-matrix-adapter
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8280
+      targetPort: 8280


### PR DESCRIPTION
## What

Adds a per-repo `manifests/` set for **matrix-adapter**, which had **none** before. This brings matrix-adapter in line with the `server/` and `client-web/` repo convention (numbered, in-repo k8s manifests for dev/test deployments + service).

| File | Purpose |
|---|---|
| `manifests/25-matrix-adapter-deployment-dev.yaml` | Dev Deployment |
| `manifests/26-matrix-adapter-deployment-test.yaml` | Test Deployment |
| `manifests/30-matrix-adapter-service.yaml` | Service |

## Source of truth

Content mirrors the authoritative dev-orchestration **base** manifests:
- `01-alkemio-platform/base/.../matrix-adapter/11-matrix-adapter-deployment.yml`
- `01-alkemio-platform/base/.../matrix-adapter/10-matrix-adapter-service.yml`

matrix-adapter has **no dev/test overlays** in dev-orchestration, so per directive the dev and test deployments are near-identical, differing only where genuinely env-specific.

## Details

- **Service**: `alkemio-matrix-adapter-service` (name matches dev-orch base exactly), port/targetPort **8280**, selector `app: alkemio-matrix-adapter`.
- **Deployment**: `alkemio-matrix-adapter-deployment`, container `alkemio-matrix-adapter`, labels `app` + `k8s-app`. Full env (RabbitMQ / Synapse / Matrix tokens / DB / logging), `resources`, and `affinity` carried over from dev-orch base.
- **Probes included** (not invented): the matrix-adapter HTTP server registers `GET /health/live` and `GET /health/ready` on port 8280 (`internal/app/app.go`, `internal/infrastructure/http/health.go`), and the dev-orch base defines matching `livenessProbe` / `readinessProbe`. Carried over verbatim.
- **dev vs test** difference is a single line — `imagePullPolicy: Always` is present on dev, absent on test — mirroring the existing `client-web` dev/test convention. Image set to the registry `:latest` tag (repo-manifest convention) rather than the pinned SHA used at deploy time in dev-orch.
- **No ingress** in-repo (per directive).

## Notes

- Validated with `kubeconform -strict` (3/3 valid) and Python YAML parse.
- Independent of the open workflow PR #60 (`ci/central-workflows`) — touches only `manifests/`, no overlap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Matrix adapter infrastructure configuration for development and test environments
  * Established service endpoint for Matrix adapter connectivity with health monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/matrix-adapter:pr-61
```

Current build: `ghcr.io/alkem-io/matrix-adapter:pr-61-1deda4f` · `linux/amd64` + `linux/arm64` · index digest `sha256:e98833066667c9b0b367771dfd018396f315489bf2effdca2b43761b395ca4f0`
<!-- pr-image-report:end -->
