### PR TITLE
ci: point reusable-workflow callers at alkem-io/github-workflows (org repo)

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    uses: antst/alkemio-github-workflows/.github/workflows/deploy-hetzner.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/deploy-hetzner.yml@v1
     with:
       environment: dev
       # All names match the org conventions derived from the repo name:

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    uses: antst/alkemio-github-workflows/.github/workflows/deploy-hetzner.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/deploy-hetzner.yml@v1
     with:
       environment: sandbox
       # Names match the org conventions derived from the repo name.

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    uses: antst/alkemio-github-workflows/.github/workflows/deploy-hetzner.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/deploy-hetzner.yml@v1
     with:
       environment: test
       # Names match the org conventions derived from the repo name.

--- a/.github/workflows/build-push-ghcr-pr.yml
+++ b/.github/workflows/build-push-ghcr-pr.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   image:
-    uses: antst/alkemio-github-workflows/.github/workflows/container-pr.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/container-pr.yml@v1
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: antst/alkemio-github-workflows/.github/workflows/container-release.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/container-release.yml@v1
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: antst/alkemio-github-workflows/.github/workflows/go-ci.yml@v1
+    uses: alkem-io/github-workflows/.github/workflows/go-ci.yml@v1
     permissions:
       contents: read
     with:


### PR DESCRIPTION
## What

Migrate all reusable-workflow callers from the personal fork \`antst/alkemio-github-workflows\` to the org repo \`alkem-io/github-workflows\`.

## Change

In every \`.github/workflows/*.yml\`, replaced \`antst/alkemio-github-workflows\` → \`alkem-io/github-workflows\` (pinned ref \`@v1\` unchanged).

Files touched (6):
- \`build-deploy-k8s-dev-hetzner.yml\` (deploy-hetzner.yml)
- \`build-deploy-k8s-sandbox-hetzner.yml\` (deploy-hetzner.yml)
- \`build-deploy-k8s-test-hetzner.yml\` (deploy-hetzner.yml)
- \`build-push-ghcr-pr.yml\` (container-pr.yml)
- \`build-release-docker-hub.yml\` (container-release.yml)
- \`ci-test.yml\` (go-ci.yml)

## Verification

- No \`antst/alkemio\` references remain.
- All workflow YAML files parse (\`python3 yaml.safe_load\`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated internal CI/CD workflow infrastructure by updating all workflow references to use a unified GitHub Actions workflow repository. This centralization improves consistency and maintainability across Kubernetes deployments, container image builds, registry publishing, and continuous integration testing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/matrix-adapter:pr-62
```

Current build: `ghcr.io/alkem-io/matrix-adapter:pr-62-facb451` · `linux/amd64` + `linux/arm64` · index digest `sha256:b55adc33587dd21f139ff45d4948964513fed3ef64e60cc80514aeb1f0798199`
<!-- pr-image-report:end -->
