### PR TITLE
chore: regenerate openapi.yaml with apispec v0.4.23

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -151,6 +151,7 @@ paths:
           description: Internal Server Error
       security:
         - apiKeyAuth: []
+      summary: handleDMRequest processes DM request webhooks from Synapse.
   /health/live:
     get:
       operationId: app.go:76:40


### PR DESCRIPTION
Mechanical regeneration of `openapi.yaml` following the central `go-ci`
reusable's default apispec bump (v0.4.21 → v0.4.23; the `@v1` tag moved).

## Why
The `ci/openapi` staleness gate on `develop` went RED because the committed
`openapi.yaml` was generated with the older apispec. This PR regenerates it
with v0.4.23 so the gate matches again.

## What changed
- `go install github.com/antst/go-apispec/cmd/apispec@v0.4.23`
- `make openapi` (no hand edits — `openapi.yaml` is generated)

The only diff is the v0.4.23 doc-comment-extraction effect: apispec now lifts
the handler method's doc comment into the operation `summary`. The
`POST /_matrix/app/alkemio/dm-request` operation gains:

```
summary: handleDMRequest processes DM request webhooks from Synapse.
```

(sourced from the `// handleDMRequest ...` comment on the `handleDMRequest`
method). No other operations changed because their handlers have no doc
comment; no `license`/`required`-set deltas apply to this repo's spec.

## Verification
- Determinism: `make openapi` run twice → `git diff --exit-code openapi.yaml`
  clean on the second pass.
- `go build ./...` — clean.
- `go test ./... -race -count=1` — all packages pass.
- `golangci-lint run` (v2.12.2) — 0 issues. No inline `//nolint`.

The PR's `ci/openapi` uses `@v1` (v0.4.23) → matches the regenerated file → green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation with additional details about direct message request webhook processing for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/matrix-adapter:pr-63
```

Current build: `ghcr.io/alkem-io/matrix-adapter:pr-63-2fe15d5` · `linux/amd64` + `linux/arm64` · index digest `sha256:56d56f48be00fdd320e328968d923d78a0276c6fae846b3be090da0df936a40f`
<!-- pr-image-report:end -->
