### PR TITLE
chore: regenerate openapi.yaml with apispec v0.4.25

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -151,6 +151,7 @@ paths:
           description: Internal Server Error
       security:
         - apiKeyAuth: []
+      summary: handleDMRequest processes DM request webhooks from Synapse.
   /health/live:
     get:
       operationId: app.go:76:40


### PR DESCRIPTION
## What

Regenerate the committed `openapi.yaml` with **apispec v0.4.25**.

## Why

The org `alkem-io/github-workflows` `go-ci` default was bumped to v0.4.25 and
`@v1` was moved (`efe1a91`). As a result, this repo's `ci/openapi` check runs
v0.4.25 against the committed spec and goes RED on `develop` until the spec is
regenerated with the matching generator version. v0.4.25 is verified
deterministic for this repo.

## Change

Generated, not hand-edited (`make openapi`). Diff is a single additive line:

- `paths./_matrix/app/.../dm` (`handleDMRequest`) gains a `summary` derived from
  its handler doc comment: *"handleDMRequest processes DM request webhooks from Synapse."*

```diff
       security:
         - apiKeyAuth: []
+      summary: handleDMRequest processes DM request webhooks from Synapse.
```

No schema, path, operation, or contract changes — purely the additive `summary`.

## Determinism

`make openapi` run consecutively; `git diff --exit-code openapi.yaml` clean
between runs (no churn from regeneration).

## Local gates (all green)

- `go build ./...` — pass
- `go test ./... -race -count=1` — pass
- `golangci-lint run` (v2.12.2) — 0 issues

Once `ci/openapi` runs the matching v0.4.25 (`@v1`), it matches the committed
spec and goes green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operation summary to the direct message request endpoint documentation for improved API clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/matrix-adapter:pr-64
```

Current build: `ghcr.io/alkem-io/matrix-adapter:pr-64-5069cda` · `linux/amd64` + `linux/arm64` · index digest `sha256:ff968febf418f8e91c9547931265df27bd343c8ba13612af64c440b89dac7830`
<!-- pr-image-report:end -->
