### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/publish-lib.yml
+++ b/.github/workflows/publish-lib.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: ${{ startsWith(github.ref, 'refs/tags/v') && 'https://registry.npmjs.org' || '' }}

--- a/.github/workflows/sync-synapse-module.yml
+++ b/.github/workflows/sync-synapse-module.yml
@@ -78,13 +78,13 @@ jobs:
 
     steps:
       - name: Checkout matrix-adapter (canonical)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: source
           persist-credentials: false
 
       - name: Checkout ${{ matrix.target.repo }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ matrix.target.repo }}
           token: ${{ secrets.ALKEMIO_INFRASTRUCTURE_BOT_PUSH_TOKEN }}


### PR DESCRIPTION
Bump GitHub Actions to latest releases (org-wide actions audit, 2026-07-21).

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v6 | v7 |
| `actions/setup-go` | v6 | v7 |
| `actions/setup-node` | v6 | v7 |

Compatibility: all `with:` inputs validated against each action's schema at the target version; bumped actions run on node24 (GitHub-hosted runners OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-image-report:start -->
---
### 📦 PR image — test the current state of this PR

```bash
docker pull ghcr.io/alkem-io/matrix-adapter:pr-68
```

Current build: `ghcr.io/alkem-io/matrix-adapter:pr-68-6a693e8` · `linux/amd64` + `linux/arm64` · index digest `sha256:113ab3df3a0271f5abaac5c90cc05ff5893ff491f839a2be533054c8c9ed6842`
<!-- pr-image-report:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated publishing and synchronization workflows to use newer action versions.
  * No changes were made to build, publishing, synchronization, or trigger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->